### PR TITLE
fix: remove nginx api proxy blocks

### DIFF
--- a/charts/chat-app/templates/configmap-nginx.yaml
+++ b/charts/chat-app/templates/configmap-nginx.yaml
@@ -31,29 +31,6 @@ data:
             image/svg+xml
             font/woff2;
 
-        location /socket.io/ {
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_read_timeout 60s;
-            proxy_pass ${API_UPSTREAM};
-        }
-
-        location /api/ {
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header Connection "";
-            proxy_read_timeout 60s;
-            proxy_pass ${API_UPSTREAM};
-        }
-
         location {{ $nginx.healthzPath }} {
             access_log off;
             default_type text/plain;


### PR DESCRIPTION
## Summary
- remove /socket.io and /api proxy blocks from the nginx configmap template
- keep SPA healthz/static routing to avoid invalid proxy_pass when API_UPSTREAM is unset

## Testing
- pnpm install
- pnpm build (VITE_API_BASE_URL=/api)
- pnpm lint
- pnpm typecheck
- helm dependency build charts/chat-app
- helm lint charts/chat-app

Ref: #6