### PR TITLE
fix(e2e): require cluster base url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,51 +34,10 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Test
+        run: pnpm test
+
       - name: Build
         run: pnpm build
         env:
           VITE_API_BASE_URL: /api
-
-  e2e:
-    name: E2E Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-          run_install: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium --with-deps
-
-      - name: Run E2E tests
-        run: pnpm test:e2e
-
-      - name: Upload test report
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 7
-
-      - name: Upload test traces
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-traces
-          path: test-results/
-          retention-days: 7

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "postinstall": "pnpm rebuild esbuild --pending",
     "test": "vitest run",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,41 +1,25 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const PORT = Number(process.env.E2E_PORT ?? 5173);
-const BASE_URL = process.env.E2E_BASE_URL ?? `http://localhost:${PORT}`;
-const USE_MOCK_SERVER = !process.env.E2E_BASE_URL;
+const BASE_URL = process.env.E2E_BASE_URL;
+
+if (!BASE_URL) {
+  throw new Error(
+    'E2E_BASE_URL is required. Run tests via: devspace run test:e2e\n' +
+      'Or set E2E_BASE_URL manually to the app URL (e.g., http://chat-app:3000).',
+  );
+}
 
 export default defineConfig({
   testDir: './test/e2e',
   fullyParallel: true,
   forbidOnly: Boolean(process.env.CI),
-  retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 2 : undefined,
-  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : [['html']],
-
+  retries: 1,
+  workers: 2,
+  reporter: [['list'], ['html', { open: 'never' }]],
   use: {
     baseURL: BASE_URL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
-
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
-  ],
-
-  ...(USE_MOCK_SERVER
-    ? {
-        webServer: {
-          command: `pnpm dev --host --port ${PORT}`,
-          port: PORT,
-          reuseExistingServer: !process.env.CI,
-          timeout: 30_000,
-          env: {
-            VITE_API_BASE_URL: '/api',
-          },
-        },
-      }
-    : {}),
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 });

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -2,4 +2,3 @@ import { test as base } from '@playwright/test';
 
 export const test = base.extend<Record<string, never>>({});
 export { expect } from '@playwright/test';
-export const isMocked = !process.env.E2E_BASE_URL;

--- a/test/e2e/thread-create.spec.ts
+++ b/test/e2e/thread-create.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, isMocked } from './fixtures';
+import { test, expect } from './fixtures';
 
 test('creates a new thread', async ({ page }) => {
   const message = 'Plan the Q3 launch roadmap.';
@@ -12,10 +12,6 @@ test('creates a new thread', async ({ page }) => {
 
   const option = page.locator('button[data-highlighted="true"]').first();
   await option.waitFor();
-
-  if (isMocked) {
-    await expect(option).toHaveText('(unknown agent)');
-  }
 
   await option.click();
 

--- a/test/e2e/thread-detail.spec.ts
+++ b/test/e2e/thread-detail.spec.ts
@@ -1,48 +1,24 @@
 import type { Page } from '@playwright/test';
-import { test, expect, isMocked } from './fixtures';
-
-const threadOne = {
-  id: '11111111-1111-1111-1111-111111111111',
-  runMessages: [
-    'Draft a Q2 marketing brief focused on the new launch.',
-    'Here is a draft brief with positioning, goals, and launch phases.',
-    'Add a section on creative deliverables and internal review dates.',
-    'Updated draft includes a deliverables checklist and review cadence.',
-  ],
-};
+import { test, expect } from './fixtures';
 
 async function openAnyThread(page: Page) {
   await page.goto('/agents/threads');
   const threadsList = page.getByTestId('threads-list');
   await expect(threadsList).toBeVisible();
-  await threadsList.locator('.cursor-pointer').first().click();
+  const firstThread = threadsList.locator('.cursor-pointer').first();
+  await expect(firstThread).toBeVisible();
+  await firstThread.click();
   await expect(page).toHaveURL(/\/agents\/threads\//);
 }
 
 test('shows thread runs', async ({ page }) => {
-  if (isMocked) {
-    await page.goto(`/agents/threads/${threadOne.id}`);
-    const runInfo = page.getByTestId('run-info');
-    await expect(runInfo).toHaveCount(2);
-    await expect(runInfo.getByText('Running')).toBeVisible();
-    await expect(runInfo.getByText('Finished')).toBeVisible();
-    return;
-  }
-
   await openAnyThread(page);
-  await expect(page.getByTestId('conversation')).toBeVisible();
+  const runInfo = page.getByTestId('run-info');
+  await expect(runInfo.first()).toBeVisible();
 });
 
 test('shows run messages', async ({ page }) => {
-  if (isMocked) {
-    await page.goto(`/agents/threads/${threadOne.id}`);
-    const conversation = page.getByTestId('conversation');
-    for (const message of threadOne.runMessages) {
-      await expect(conversation.getByText(message)).toBeVisible();
-    }
-    return;
-  }
-
   await openAnyThread(page);
-  await expect(page.getByTestId('conversation')).toBeVisible();
+  const messages = page.getByTestId('conversation-message');
+  await expect(messages.first()).toBeVisible();
 });

--- a/test/e2e/threads-list.spec.ts
+++ b/test/e2e/threads-list.spec.ts
@@ -1,21 +1,11 @@
-import { test, expect, isMocked } from './fixtures';
-
-const threadOne = {
-  id: '11111111-1111-1111-1111-111111111111',
-  summary: 'Draft a Q2 marketing brief for the launch campaign.',
-  agentName: 'Campaign Planner',
-};
+import { test, expect } from './fixtures';
 
 test('renders thread list on load', async ({ page }) => {
   await page.goto('/agents/threads');
 
   const threadsList = page.getByTestId('threads-list');
   await expect(threadsList).toBeVisible();
-
-  if (isMocked) {
-    await expect(threadsList.getByText(threadOne.summary)).toBeVisible();
-    await expect(threadsList.getByText(threadOne.agentName)).toBeVisible();
-  }
+  await expect(threadsList.locator('.cursor-pointer').first()).toBeVisible();
 });
 
 test('navigates to thread detail', async ({ page }) => {
@@ -24,14 +14,9 @@ test('navigates to thread detail', async ({ page }) => {
   const threadsList = page.getByTestId('threads-list');
   await expect(threadsList).toBeVisible();
 
-  if (isMocked) {
-    await threadsList.getByText(threadOne.summary).click();
-    await expect(page).toHaveURL(`/agents/threads/${threadOne.id}`);
-    await expect(page.getByRole('heading', { name: threadOne.summary })).toBeVisible();
-    return;
-  }
-
-  await threadsList.locator('.cursor-pointer').first().click();
+  const firstThread = threadsList.locator('.cursor-pointer').first();
+  await expect(firstThread).toBeVisible();
+  await firstThread.click();
   await expect(page).toHaveURL(/\/agents\/threads\//);
   await expect(page.getByTestId('conversation')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- remove CI e2e job and run vitest unit tests in build job
- enforce required E2E_BASE_URL in Playwright config and simplify fixtures/specs for cluster data
- drop interactive Playwright UI script

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm test:e2e (fails without E2E_BASE_URL as expected)

Closes #8