### PR TITLE
chore(e2e): route tests via ingress

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -38,7 +38,7 @@ deployments:
           - image: ${E2E_IMAGE}
             env:
               - name: E2E_BASE_URL
-                value: "http://chat-app:3000"
+                value: "https://chat.agyn.dev"
         labels:
           app.kubernetes.io/name: chat-app-e2e
 
@@ -64,24 +64,31 @@ pipelines:
 
   test-e2e:
     run: |-
+      GATEWAY_IP=$(kubectl get svc istio-ingressgateway -n istio-gateway -o jsonpath='{.spec.clusterIP}')
+      if [ -z "$GATEWAY_IP" ]; then
+        echo "ERROR: Could not resolve istio-ingressgateway ClusterIP" >&2
+        exit 1
+      fi
+      echo "Resolved istio-ingressgateway ClusterIP: $GATEWAY_IP"
       create_deployments e2e-runner
       start_dev e2e-runner &
       sleep 5
       exec_container \
         --label-selector "app.kubernetes.io/name=chat-app-e2e" \
         -n ${APP_NAMESPACE} \
-        -- bash -c '
-          echo "Waiting for file sync..."
-          for i in $(seq 1 60); do
+        -- bash -c "
+          echo '$GATEWAY_IP chat.agyn.dev' >> /etc/hosts
+          echo 'Waiting for file sync...'
+          for i in \$(seq 1 60); do
             [ -f /opt/app/data/pnpm-lock.yaml ] && break
             sleep 2
           done
           if [ ! -f /opt/app/data/pnpm-lock.yaml ]; then
-            echo "ERROR: File sync timed out (pnpm-lock.yaml not found after 120s)"
+            echo 'ERROR: File sync timed out (pnpm-lock.yaml not found after 120s)'
             exit 1
           fi
           cd /opt/app/data && corepack enable && pnpm install --frozen-lockfile && pnpm test:e2e
-        '
+        "
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   reporter: [['list'], ['html', { open: 'never' }]],
   use: {
     baseURL: BASE_URL,
+    ignoreHTTPSErrors: true,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },


### PR DESCRIPTION
## Summary
- update the e2e runner base URL to use the Istio ingress hostname
- resolve the ingress ClusterIP and inject /etc/hosts before running e2e
- allow Playwright to ignore HTTPS errors for the k3d cert

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- VITE_API_BASE_URL=/api pnpm exec vite --host 0.0.0.0 --port 3000
- E2E_BASE_URL=http://localhost:3000 pnpm test:e2e

Refs #12