### PR TITLE
fix(nginx): restore api proxy blocks

### DIFF
--- a/charts/chat-app/templates/configmap-nginx.yaml
+++ b/charts/chat-app/templates/configmap-nginx.yaml
@@ -31,6 +31,41 @@ data:
             image/svg+xml
             font/woff2;
 
+        location /socket.io/ {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 60s;
+            proxy_pass ${API_UPSTREAM};
+        }
+
+        location /apiv2/ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Connection "";
+            proxy_read_timeout 60s;
+            rewrite ^/apiv2(/.*)?$ $1 break;
+            proxy_pass ${API_UPSTREAM};
+        }
+
+        location /api/ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Connection "";
+            proxy_read_timeout 60s;
+            proxy_pass ${API_UPSTREAM};
+        }
+
         location {{ $nginx.healthzPath }} {
             access_log off;
             default_type text/plain;

--- a/docker/default.conf.template
+++ b/docker/default.conf.template
@@ -20,6 +20,41 @@ server {
         image/svg+xml
         font/woff2;
 
+    location /socket.io/ {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+        proxy_pass ${API_UPSTREAM};
+    }
+
+    location /apiv2/ {
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_read_timeout 60s;
+        rewrite ^/apiv2(/.*)?$ $1 break;
+        proxy_pass ${API_UPSTREAM};
+    }
+
+    location /api/ {
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_read_timeout 60s;
+        proxy_pass ${API_UPSTREAM};
+    }
+
     location /healthz {
         access_log off;
         default_type text/plain;


### PR DESCRIPTION
## Summary
- restore /api/, /apiv2/, and /socket.io/ proxy locations in nginx templates

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- VITE_API_BASE_URL=/api pnpm exec vite --host 0.0.0.0 --port 3000
- E2E_BASE_URL=http://localhost:3000 pnpm test:e2e

Refs #12