### PR TITLE
fix(api): switch gateway to /api

### DIFF
--- a/src/api/modules/chat.ts
+++ b/src/api/modules/chat.ts
@@ -12,7 +12,7 @@ import type {
   SendMessageResponse,
 } from '@/api/types/chat';
 
-const CHAT_SERVICE = '/apiv2/agynio.api.gateway.v1.ChatGateway';
+const CHAT_SERVICE = '/api/agynio.api.gateway.v1.ChatGateway';
 
 function connectPost<TReq, TRes>(method: string, req: TReq): Promise<TRes> {
   return http.post<TRes>(`${CHAT_SERVICE}/${method}`, req, {

--- a/src/api/modules/files.ts
+++ b/src/api/modules/files.ts
@@ -12,7 +12,7 @@ export function uploadFile(
   const formData = new FormData();
   formData.append('file', file);
 
-  return http.post<FileRecord>('/apiv2/files/v1/files', formData, {
+  return http.post<FileRecord>('/api/files/v1/files', formData, {
     headers: { 'Content-Type': 'multipart/form-data' },
     onUploadProgress,
     signal,

--- a/vite-plugin-mock-api.ts
+++ b/vite-plugin-mock-api.ts
@@ -584,7 +584,7 @@ export function mockApiPlugin(): Plugin {
         const url = new URL(req.url, 'http://localhost');
         const { pathname } = url;
         const method = req.method ?? 'GET';
-        const chatPrefix = '/apiv2/agynio.api.gateway.v1.ChatGateway/';
+        const chatPrefix = '/api/agynio.api.gateway.v1.ChatGateway/';
 
         if (pathname.startsWith(chatPrefix)) {
           if (method !== 'POST') {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,8 @@ import { defineConfig } from 'vite';
 import { configDefaults } from 'vitest/config';
 import { mockApiPlugin } from './vite-plugin-mock-api';
 
+const gatewayTarget = process.env.VITE_GATEWAY_URL || 'http://gateway:8080';
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss(), mockApiPlugin()],
@@ -15,12 +17,12 @@ export default defineConfig({
     allowedHosts: true,
     proxy: {
       '/socket.io': {
-        target: process.env.VITE_PROXY_TARGET || 'http://platform-server:3010',
+        target: gatewayTarget,
         changeOrigin: true,
         ws: true,
       },
-      '/apiv2': {
-        target: process.env.VITE_LLM_GATEWAY_URL || 'http://llm-gateway:8080',
+      '/api': {
+        target: gatewayTarget,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary
- update chat and file gateway paths to `/api`
- align Vite proxy targets with the gateway
- adjust mock API chat prefix for the new gateway path

## Testing
- pnpm typecheck
- pnpm lint
- pnpm build

Closes #22