### PR TITLE
Update bootstrap checkout ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: agynio/bootstrap
-          ref: noa/issue-136
+          ref: main
           path: bootstrap
 
       - name: Install kubectl


### PR DESCRIPTION
## Summary
- update bootstrap checkout ref to main in CI

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- VITE_API_BASE_URL=http://localhost pnpm dev --host 127.0.0.1 --port 5173 (background)
- E2E_BASE_URL=http://127.0.0.1:5173 pnpm test:e2e

Closes #24