### PR TITLE
feat: inline media display

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 VITE_API_BASE_URL=/api
+# VITE_MEDIA_PROXY_URL=https://media.agyn.dev
 # VITE_OIDC_AUTHORITY=https://login.example.com/realms/agyn
 # VITE_OIDC_CLIENT_ID=chat-app
 # VITE_OIDC_SCOPE=openid profile email

--- a/charts/chat-app/templates/configmap-nginx.yaml
+++ b/charts/chat-app/templates/configmap-nginx.yaml
@@ -56,5 +56,11 @@ data:
             add_header Cache-Control "no-cache" always;
             alias /tmp/__config.js;
         }
+
+        location = /sw.js {
+            add_header Cache-Control "no-cache" always;
+            add_header Service-Worker-Allowed "/" always;
+            try_files $uri =404;
+        }
     }
 {{- end }}

--- a/docker/40-generate-config.sh
+++ b/docker/40-generate-config.sh
@@ -8,6 +8,7 @@ escape_js() {
 }
 
 api_base_url=$(escape_js "${API_BASE_URL:-}")
+media_proxy_url=$(escape_js "${MEDIA_PROXY_URL:-}")
 oidc_authority=$(escape_js "${OIDC_AUTHORITY:-}")
 oidc_client_id=$(escape_js "${OIDC_CLIENT_ID:-}")
 oidc_scope=$(escape_js "${OIDC_SCOPE:-}")
@@ -15,6 +16,7 @@ oidc_scope=$(escape_js "${OIDC_SCOPE:-}")
 cat > "$CONFIG_PATH" <<EOF
 window.__APP_CONFIG = {
   API_BASE_URL: "${api_base_url}",
+  MEDIA_PROXY_URL: "${media_proxy_url}",
   OIDC_AUTHORITY: "${oidc_authority}",
   OIDC_CLIENT_ID: "${oidc_client_id}",
   OIDC_SCOPE: "${oidc_scope}",

--- a/docker/default.conf.template
+++ b/docker/default.conf.template
@@ -45,4 +45,10 @@ server {
         add_header Cache-Control "no-cache" always;
         alias /tmp/__config.js;
     }
+
+    location = /sw.js {
+        add_header Cache-Control "no-cache" always;
+        add_header Service-Worker-Allowed "/" always;
+        try_files $uri =404;
+    }
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.2",
+    "esbuild": "^0.28.0",
     "eslint": "^9.35.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,7 +32,16 @@ export default defineConfig({
     ignoreHTTPSErrors: true,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    serviceWorkers: 'block',
   },
-  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: ['--ignore-certificate-errors'],
+        },
+      },
+    },
+  ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
     ignoreHTTPSErrors: true,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    serviceWorkers: 'block',
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.0.2
         version: 5.2.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
       eslint:
         specifier: ^9.35.0
         version: 9.39.4(jiti@2.6.1)
@@ -331,8 +334,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -343,8 +358,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -355,8 +382,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.4':
     resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -367,8 +406,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.4':
     resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -379,8 +430,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.4':
     resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -391,8 +454,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.4':
     resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -403,8 +478,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.4':
     resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -415,8 +502,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.4':
     resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -427,8 +526,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -439,8 +550,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -451,8 +574,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -463,8 +598,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -475,8 +622,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.4':
     resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1896,6 +2055,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3255,79 +3419,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.27.4':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
@@ -4767,6 +5009,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.4
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
 

--- a/src/api/modules/files.ts
+++ b/src/api/modules/files.ts
@@ -1,15 +1,56 @@
+import { connectPost } from '@/api/connect';
 import { uploadFileViaConnect } from '@/api/upload-file-connect';
-import type { FileRecord } from '@/api/types/files';
+import type { FileRecord, FileMetadata, GetFileMetadataRequest, GetFileMetadataResponse } from '@/api/types/files';
 import type { UploadProgressHandler } from '@/api/types/upload';
 
 export type { UploadProgressEvent, UploadProgressHandler } from '@/api/types/upload';
 
-function parseSizeBytes(sizeBytes: string | bigint): number {
-  const parsed = typeof sizeBytes === 'bigint' ? Number(sizeBytes) : Number.parseInt(sizeBytes, 10);
+const FILES_SERVICE = '/api/agynio.api.gateway.v1.FilesGateway';
+
+type FileMetadataWire = {
+  id?: string;
+  filename?: string;
+  contentType?: string;
+  sizeBytes?: string | number | bigint;
+  createdAt?: string;
+};
+
+function parseSizeBytes(sizeBytes: string | number | bigint): number {
+  const parsed = typeof sizeBytes === 'bigint'
+    ? Number(sizeBytes)
+    : typeof sizeBytes === 'number'
+      ? sizeBytes
+      : Number.parseInt(sizeBytes, 10);
   if (!Number.isFinite(parsed)) {
     throw new Error(`Invalid sizeBytes: ${sizeBytes}`);
   }
   return parsed;
+}
+
+function normalizeFileRecord(file: FileMetadataWire): FileRecord {
+  if (!file.id) {
+    throw new Error('File metadata missing id');
+  }
+  if (!file.filename) {
+    throw new Error('File metadata missing filename');
+  }
+  if (!file.contentType) {
+    throw new Error('File metadata missing contentType');
+  }
+  if (file.sizeBytes === undefined) {
+    throw new Error('File metadata missing sizeBytes');
+  }
+  if (!file.createdAt) {
+    throw new Error('File metadata missing createdAt');
+  }
+
+  return {
+    id: file.id,
+    filename: file.filename,
+    contentType: file.contentType,
+    sizeBytes: parseSizeBytes(file.sizeBytes),
+    createdAt: file.createdAt,
+  } satisfies FileRecord;
 }
 
 export async function uploadFile(
@@ -22,11 +63,20 @@ export async function uploadFile(
     throw new Error('UploadFile response missing file');
   }
 
-  return {
-    id: response.file.id,
-    filename: response.file.filename,
-    contentType: response.file.contentType,
-    sizeBytes: parseSizeBytes(response.file.sizeBytes),
-    createdAt: response.file.createdAt,
-  } satisfies FileRecord;
+  return normalizeFileRecord(response.file as FileMetadataWire);
+}
+
+export async function getFileMetadata(fileId: string): Promise<FileRecord> {
+  const response = await connectPost<GetFileMetadataRequest, GetFileMetadataResponse>(
+    FILES_SERVICE,
+    'GetFileMetadata',
+    { fileId },
+  );
+
+  const file = response.file ?? (response as unknown as FileMetadata);
+  if (!file) {
+    throw new Error('GetFileMetadata response missing file');
+  }
+
+  return normalizeFileRecord(file as FileMetadataWire);
 }

--- a/src/api/modules/files.ts
+++ b/src/api/modules/files.ts
@@ -1,19 +1,11 @@
 import { connectPost } from '@/api/connect';
 import { uploadFileViaConnect } from '@/api/upload-file-connect';
-import type { FileRecord, FileMetadata, GetFileMetadataRequest, GetFileMetadataResponse } from '@/api/types/files';
+import type { FileMetadataWire, FileRecord, GetFileMetadataRequest, GetFileMetadataResponse } from '@/api/types/files';
 import type { UploadProgressHandler } from '@/api/types/upload';
 
 export type { UploadProgressEvent, UploadProgressHandler } from '@/api/types/upload';
 
 const FILES_SERVICE = '/api/agynio.api.gateway.v1.FilesGateway';
-
-type FileMetadataWire = {
-  id?: string;
-  filename?: string;
-  contentType?: string;
-  sizeBytes?: string | number | bigint;
-  createdAt?: string;
-};
 
 function parseSizeBytes(sizeBytes: string | number | bigint): number {
   const parsed = typeof sizeBytes === 'bigint'
@@ -63,7 +55,7 @@ export async function uploadFile(
     throw new Error('UploadFile response missing file');
   }
 
-  return normalizeFileRecord(response.file as FileMetadataWire);
+  return normalizeFileRecord(response.file);
 }
 
 export async function getFileMetadata(fileId: string): Promise<FileRecord> {
@@ -73,10 +65,9 @@ export async function getFileMetadata(fileId: string): Promise<FileRecord> {
     { fileId },
   );
 
-  const file = response.file ?? (response as unknown as FileMetadata);
-  if (!file) {
+  if (!response.file) {
     throw new Error('GetFileMetadata response missing file');
   }
 
-  return normalizeFileRecord(file as FileMetadataWire);
+  return normalizeFileRecord(response.file);
 }

--- a/src/api/types/files.ts
+++ b/src/api/types/files.ts
@@ -5,3 +5,14 @@ export type FileRecord = {
   sizeBytes: number;
   createdAt: string;
 };
+
+export type FileMetadata = {
+  id: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: string | number;
+  createdAt: string;
+};
+
+export type GetFileMetadataRequest = { fileId: string };
+export type GetFileMetadataResponse = { file?: FileMetadata };

--- a/src/api/types/files.ts
+++ b/src/api/types/files.ts
@@ -6,13 +6,13 @@ export type FileRecord = {
   createdAt: string;
 };
 
-export type FileMetadata = {
-  id: string;
-  filename: string;
-  contentType: string;
-  sizeBytes: string | number;
-  createdAt: string;
+export type FileMetadataWire = {
+  id?: string;
+  filename?: string;
+  contentType?: string;
+  sizeBytes?: string | number | bigint;
+  createdAt?: string;
 };
 
 export type GetFileMetadataRequest = { fileId: string };
-export type GetFileMetadataResponse = { file?: FileMetadata };
+export type GetFileMetadataResponse = { file?: FileMetadataWire };

--- a/src/components/MarkdownContent.test.tsx
+++ b/src/components/MarkdownContent.test.tsx
@@ -1,0 +1,36 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mediaImageSpy = vi.fn();
+
+vi.mock('./MediaImage', () => ({
+  MediaImage: (props: { src: string }) => {
+    mediaImageSpy(props);
+    return null;
+  },
+}));
+
+vi.mock('./MediaAudio', () => ({
+  MediaAudio: () => null,
+}));
+
+vi.mock('./MediaVideo', () => ({
+  MediaVideo: () => null,
+}));
+
+describe('MarkdownContent', () => {
+  beforeEach(() => {
+    mediaImageSpy.mockClear();
+  });
+
+  it('passes agyn protocol urls to MediaImage', async () => {
+    const { MarkdownContent } = await import('./MarkdownContent');
+    const url = 'agyn://file/some-uuid';
+
+    renderToStaticMarkup(<MarkdownContent content={`![test](${url})`} />);
+
+    expect(mediaImageSpy).toHaveBeenCalledOnce();
+    const [props] = mediaImageSpy.mock.calls[0] as [{ src?: string }];
+    expect(props.src).toBe(url);
+  });
+});

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -1,5 +1,4 @@
-import ReactMarkdown from 'react-markdown';
-import type { Components } from 'react-markdown';
+import ReactMarkdown, { defaultUrlTransform, type Components } from 'react-markdown';
 import {
   Children,
   cloneElement,
@@ -63,6 +62,14 @@ const getCodeRenderMeta = ({ inline, className }: MarkdownCodeProps) => {
 };
 
 const normalizeAltText = (alt?: string) => alt?.trim().toLowerCase() ?? '';
+const AGYN_PROTOCOL_PREFIX = 'agyn:';
+
+function urlTransform(url: string): string {
+  if (url.startsWith(AGYN_PROTOCOL_PREFIX)) {
+    return url;
+  }
+  return defaultUrlTransform(url);
+}
 
 const resolveSourceFromChildren = (children: ReactNode): string | null => {
   const nodes = Children.toArray(children);
@@ -346,6 +353,7 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
         remarkPlugins={MARKDOWN_REMARK_PLUGINS}
         rehypePlugins={MARKDOWN_REHYPE_PLUGINS}
         components={markdownComponents}
+        urlTransform={urlTransform}
       >
         {content}
       </ReactMarkdown>

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -10,6 +10,9 @@ import {
 } from 'react';
 import { MARKDOWN_REMARK_PLUGINS, MARKDOWN_REHYPE_PLUGINS } from '@/lib/markdown/config';
 import { cn } from '@/lib/utils';
+import { MediaAudio } from './MediaAudio';
+import { MediaImage } from './MediaImage';
+import { MediaVideo } from './MediaVideo';
 
 interface MarkdownContentProps {
   content: string;
@@ -22,6 +25,22 @@ type MarkdownCodeProps = ComponentPropsWithoutRef<'code'> & {
 };
 
 type MarkdownPreProps = ComponentPropsWithoutRef<'pre'> & {
+  node?: unknown;
+};
+
+type MarkdownImageProps = ComponentPropsWithoutRef<'img'> & {
+  node?: unknown;
+};
+
+type MarkdownVideoProps = ComponentPropsWithoutRef<'video'> & {
+  node?: unknown;
+};
+
+type MarkdownAudioProps = ComponentPropsWithoutRef<'audio'> & {
+  node?: unknown;
+};
+
+type MarkdownSourceProps = ComponentPropsWithoutRef<'source'> & {
   node?: unknown;
 };
 
@@ -41,6 +60,25 @@ const getCodeRenderMeta = ({ inline, className }: MarkdownCodeProps) => {
   const match = /language-(\w+)/.exec(className || '');
   const isInlineCode = inline ?? !match;
   return { match, isInlineCode } as const;
+};
+
+const normalizeAltText = (alt?: string) => alt?.trim().toLowerCase() ?? '';
+
+const resolveSourceFromChildren = (children: ReactNode): string | null => {
+  const nodes = Children.toArray(children);
+  for (const node of nodes) {
+    if (!isValidElement<MarkdownSourceProps>(node)) {
+      continue;
+    }
+    if (node.type !== 'source') {
+      continue;
+    }
+    const src = typeof node.props.src === 'string' ? node.props.src.trim() : '';
+    if (src) {
+      return src;
+    }
+  }
+  return null;
 };
 
 export function MarkdownContent({ content, className = '' }: MarkdownContentProps) {
@@ -141,6 +179,39 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
 
     // Inline code
     code: renderCode,
+
+    img: ({ src, alt, title, className: imageClassName, node: _node }: MarkdownImageProps) => {
+      const normalizedAlt = normalizeAltText(alt);
+      const resolvedSrc = typeof src === 'string' ? src : '';
+
+      if (normalizedAlt === 'video') {
+        return <MediaVideo src={resolvedSrc} className={imageClassName} />;
+      }
+
+      if (normalizedAlt === 'audio') {
+        return <MediaAudio src={resolvedSrc} className={imageClassName} />;
+      }
+
+      return <MediaImage src={resolvedSrc} alt={alt ?? ''} title={title} className={imageClassName} />;
+    },
+
+    video: ({ src, children, className: videoClassName, node: _node }: MarkdownVideoProps) => {
+      const resolvedSrc = typeof src === 'string' && src.trim() ? src : resolveSourceFromChildren(children) ?? '';
+      return <MediaVideo src={resolvedSrc} className={videoClassName} />;
+    },
+
+    audio: ({ src, children, className: audioClassName, node: _node }: MarkdownAudioProps) => {
+      const resolvedSrc = typeof src === 'string' && src.trim() ? src : resolveSourceFromChildren(children) ?? '';
+      return <MediaAudio src={resolvedSrc} className={audioClassName} />;
+    },
+
+    source: ({ node: _node, ..._props }: MarkdownSourceProps) => null,
+
+    picture: ({ children }) => (
+      <span className="block max-w-full">
+        {children}
+      </span>
+    ),
 
     // Code blocks
     pre: ({ children, className: preClassName, style: preStyle, node: _node, ...props }: MarkdownPreProps) => {

--- a/src/components/MediaAudio.tsx
+++ b/src/components/MediaAudio.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useMemo, useState } from 'react';
+import { buildDownloadUrl, buildProxyUrl } from '@/lib/media/proxy-url';
+import { cn } from '@/lib/utils';
+import { MediaDownloadLink } from './MediaDownloadLink';
+import { MediaFallback } from './MediaFallback';
+
+interface MediaAudioProps {
+  src: string;
+  label?: string;
+  className?: string;
+}
+
+export function MediaAudio({ src, label = 'Audio', className = '' }: MediaAudioProps) {
+  const normalizedSrc = src.trim();
+  const proxyUrl = useMemo(() => (normalizedSrc ? buildProxyUrl(normalizedSrc) : null), [normalizedSrc]);
+  const downloadUrl = useMemo(() => (normalizedSrc ? buildDownloadUrl(normalizedSrc) : null), [normalizedSrc]);
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    setHasError(false);
+  }, [proxyUrl]);
+
+  if (!proxyUrl || hasError) {
+    return (
+      <MediaFallback
+        filename={label}
+        description={hasError ? 'Audio failed to load.' : 'Audio unavailable.'}
+        downloadUrl={downloadUrl}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-2', className)}>
+      <audio
+        className="w-full"
+        controls
+        preload="metadata"
+        src={proxyUrl}
+        onError={() => setHasError(true)}
+      />
+      <MediaDownloadLink href={downloadUrl} />
+    </div>
+  );
+}

--- a/src/components/MediaAudio.tsx
+++ b/src/components/MediaAudio.tsx
@@ -22,23 +22,25 @@ export function MediaAudio({ src, label = 'Audio', className = '' }: MediaAudioP
 
   if (!proxyUrl || hasError) {
     return (
-      <MediaFallback
-        filename={label}
-        description={hasError ? 'Audio failed to load.' : 'Audio unavailable.'}
-        downloadUrl={downloadUrl}
-        className={className}
-      />
+      <div className={cn('flex flex-col gap-2', className)} data-testid="media-audio">
+        <MediaFallback
+          filename={label}
+          description={hasError ? 'Audio failed to load.' : 'Audio unavailable.'}
+          downloadUrl={downloadUrl}
+        />
+      </div>
     );
   }
 
   return (
-    <div className={cn('flex flex-col gap-2', className)}>
+    <div className={cn('flex flex-col gap-2', className)} data-testid="media-audio">
       <audio
         className="w-full"
         controls
         preload="metadata"
         src={proxyUrl}
         onError={() => setHasError(true)}
+        data-testid="media-audio-element"
       />
       <MediaDownloadLink href={downloadUrl} />
     </div>

--- a/src/components/MediaDownloadLink.tsx
+++ b/src/components/MediaDownloadLink.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@/lib/utils';
+
+interface MediaDownloadLinkProps {
+  href?: string | null;
+  label?: string;
+  className?: string;
+}
+
+export function MediaDownloadLink({
+  href,
+  label = 'Download original',
+  className = '',
+}: MediaDownloadLinkProps) {
+  if (!href) {
+    return (
+      <span className={cn('text-xs text-[var(--agyn-gray)]', className)}>
+        Download unavailable
+      </span>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        'text-xs text-[var(--agyn-blue)] hover:text-[var(--agyn-purple)] underline transition-colors',
+        className,
+      )}
+    >
+      {label}
+    </a>
+  );
+}

--- a/src/components/MediaDownloadLink.tsx
+++ b/src/components/MediaDownloadLink.tsx
@@ -13,7 +13,10 @@ export function MediaDownloadLink({
 }: MediaDownloadLinkProps) {
   if (!href) {
     return (
-      <span className={cn('text-xs text-[var(--agyn-gray)]', className)}>
+      <span
+        className={cn('text-xs text-[var(--agyn-gray)]', className)}
+        data-testid="media-download-link"
+      >
         Download unavailable
       </span>
     );
@@ -28,6 +31,7 @@ export function MediaDownloadLink({
         'text-xs text-[var(--agyn-blue)] hover:text-[var(--agyn-purple)] underline transition-colors',
         className,
       )}
+      data-testid="media-download-link"
     >
       {label}
     </a>

--- a/src/components/MediaFallback.tsx
+++ b/src/components/MediaFallback.tsx
@@ -31,6 +31,7 @@ export function MediaFallback({
         'flex items-center gap-3 rounded-[12px] border border-[var(--agyn-border-subtle)] bg-white p-3',
         className,
       )}
+      data-testid="media-fallback"
     >
       <div className="flex h-10 w-10 items-center justify-center rounded-[10px] bg-[var(--agyn-bg-light)]">
         <File className="h-5 w-5 text-[var(--agyn-gray)]" aria-hidden="true" />

--- a/src/components/MediaFallback.tsx
+++ b/src/components/MediaFallback.tsx
@@ -1,0 +1,49 @@
+import { File } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { formatFileSize } from '@/utils/formatFileSize';
+import { MediaDownloadLink } from './MediaDownloadLink';
+
+interface MediaFallbackProps {
+  filename: string;
+  contentType?: string | null;
+  sizeBytes?: number | null;
+  downloadUrl?: string | null;
+  description?: string;
+  downloadLabel?: string;
+  className?: string;
+}
+
+export function MediaFallback({
+  filename,
+  contentType,
+  sizeBytes,
+  downloadUrl,
+  description,
+  downloadLabel = 'Download file',
+  className = '',
+}: MediaFallbackProps) {
+  const metadataParts = [contentType, sizeBytes ? formatFileSize(sizeBytes) : null].filter(Boolean);
+  const metadata = description ?? (metadataParts.length > 0 ? metadataParts.join(' | ') : 'File');
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3 rounded-[12px] border border-[var(--agyn-border-subtle)] bg-white p-3',
+        className,
+      )}
+    >
+      <div className="flex h-10 w-10 items-center justify-center rounded-[10px] bg-[var(--agyn-bg-light)]">
+        <File className="h-5 w-5 text-[var(--agyn-gray)]" aria-hidden="true" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-[var(--agyn-dark)]" title={filename}>
+          {filename}
+        </div>
+        <div className="text-xs text-[var(--agyn-gray)]">
+          {metadata}
+        </div>
+      </div>
+      <MediaDownloadLink href={downloadUrl} label={downloadLabel} />
+    </div>
+  );
+}

--- a/src/components/MediaImage.tsx
+++ b/src/components/MediaImage.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useMemo, useState } from 'react';
+import { buildDownloadUrl, buildProxyUrl, INLINE_IMAGE_MAX_SIZE } from '@/lib/media/proxy-url';
+import { cn } from '@/lib/utils';
+import { MediaDownloadLink } from './MediaDownloadLink';
+
+type LoadState = 'loading' | 'loaded' | 'error';
+
+interface MediaImageProps {
+  src: string;
+  alt?: string;
+  title?: string;
+  className?: string;
+}
+
+export function MediaImage({ src, alt = '', title, className = '' }: MediaImageProps) {
+  const normalizedSrc = src.trim();
+  const proxyUrl = useMemo(
+    () => (normalizedSrc ? buildProxyUrl(normalizedSrc, { size: INLINE_IMAGE_MAX_SIZE }) : null),
+    [normalizedSrc],
+  );
+  const downloadUrl = useMemo(
+    () => (normalizedSrc ? buildDownloadUrl(normalizedSrc) : null),
+    [normalizedSrc],
+  );
+
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [retryKey, setRetryKey] = useState(0);
+
+  useEffect(() => {
+    setLoadState('loading');
+    setRetryKey(0);
+  }, [proxyUrl]);
+
+  if (!proxyUrl) {
+    return (
+      <div className={cn('flex flex-col gap-2', className)}>
+        <div className="rounded-[12px] border border-[var(--agyn-border-subtle)] bg-[var(--agyn-bg-light)] p-3 text-xs text-[var(--agyn-gray)]">
+          {alt ? `Image unavailable: ${alt}` : 'Image unavailable.'}
+        </div>
+        <MediaDownloadLink href={downloadUrl} />
+      </div>
+    );
+  }
+
+  const handleRetry = () => {
+    setLoadState('loading');
+    setRetryKey((prev) => prev + 1);
+  };
+
+  return (
+    <div className={cn('flex flex-col gap-2', className)}>
+      <div className="relative max-w-full">
+        {loadState === 'loading' ? (
+          <div className="h-48 w-full animate-pulse rounded-[12px] bg-[var(--agyn-bg-light)]" />
+        ) : null}
+        {loadState === 'error' ? (
+          <div className="flex flex-col gap-2 rounded-[12px] border border-[var(--agyn-border-subtle)] bg-[var(--agyn-bg-light)] p-3">
+            <span className="text-xs text-[var(--agyn-gray)]">
+              {alt ? `Image failed to load: ${alt}` : 'Image failed to load.'}
+            </span>
+            <button
+              type="button"
+              onClick={handleRetry}
+              className="text-xs text-[var(--agyn-blue)] hover:text-[var(--agyn-purple)] underline"
+            >
+              Retry
+            </button>
+          </div>
+        ) : (
+          <img
+            key={retryKey}
+            src={proxyUrl}
+            alt={alt}
+            title={title}
+            loading="lazy"
+            onLoad={() => setLoadState('loaded')}
+            onError={() => setLoadState('error')}
+            className={cn(
+              'max-h-[360px] w-full rounded-[12px] border border-[var(--agyn-border-subtle)] object-contain',
+              loadState === 'loading' ? 'opacity-0' : 'opacity-100',
+            )}
+          />
+        )}
+      </div>
+      <MediaDownloadLink href={downloadUrl} />
+    </div>
+  );
+}

--- a/src/components/MediaImage.tsx
+++ b/src/components/MediaImage.tsx
@@ -51,8 +51,11 @@ export function MediaImage({ src, alt = '', title, className = '' }: MediaImageP
 
   if (!proxyUrl) {
     return (
-      <div className={cn('flex flex-col gap-2', className)}>
-        <div className="rounded-[12px] border border-[var(--agyn-border-subtle)] bg-[var(--agyn-bg-light)] p-3 text-xs text-[var(--agyn-gray)]">
+      <div className={cn('flex flex-col gap-2', className)} data-testid="media-image">
+        <div
+          className="rounded-[12px] border border-[var(--agyn-border-subtle)] bg-[var(--agyn-bg-light)] p-3 text-xs text-[var(--agyn-gray)]"
+          data-testid="media-image-unavailable"
+        >
           {alt ? `Image unavailable: ${alt}` : 'Image unavailable.'}
         </div>
         <MediaDownloadLink href={downloadUrl} />
@@ -66,12 +69,18 @@ export function MediaImage({ src, alt = '', title, className = '' }: MediaImageP
   };
 
   return (
-    <div className={cn('flex flex-col gap-2', className)}>
+    <div className={cn('flex flex-col gap-2', className)} data-testid="media-image">
       <div className="relative max-w-full">
         {loadState === 'loading' ? (
-          <div className="h-48 w-full animate-pulse rounded-[12px] bg-[var(--agyn-bg-light)]" />
+          <div
+            className="h-48 w-full animate-pulse rounded-[12px] bg-[var(--agyn-bg-light)]"
+            data-testid="media-image-loading"
+          />
         ) : loadState === 'error' ? (
-          <div className="flex flex-col gap-2 rounded-[12px] border border-[var(--agyn-border-subtle)] bg-[var(--agyn-bg-light)] p-3">
+          <div
+            className="flex flex-col gap-2 rounded-[12px] border border-[var(--agyn-border-subtle)] bg-[var(--agyn-bg-light)] p-3"
+            data-testid="media-image-error"
+          >
             <span className="text-xs text-[var(--agyn-gray)]">
               {alt ? `Image failed to load: ${alt}` : 'Image failed to load.'}
             </span>
@@ -91,6 +100,7 @@ export function MediaImage({ src, alt = '', title, className = '' }: MediaImageP
             title={title}
             loading="lazy"
             className="max-h-[360px] w-full rounded-[12px] border border-[var(--agyn-border-subtle)] object-contain"
+            data-testid="media-image-element"
           />
         )}
       </div>

--- a/src/components/MediaImage.tsx
+++ b/src/components/MediaImage.tsx
@@ -27,9 +27,27 @@ export function MediaImage({ src, alt = '', title, className = '' }: MediaImageP
   const [retryKey, setRetryKey] = useState(0);
 
   useEffect(() => {
+    if (!proxyUrl) return;
     setLoadState('loading');
-    setRetryKey(0);
-  }, [proxyUrl]);
+
+    let cancelled = false;
+    const image = new Image();
+    image.onload = () => {
+      if (!cancelled) {
+        setLoadState('loaded');
+      }
+    };
+    image.onerror = () => {
+      if (!cancelled) {
+        setLoadState('error');
+      }
+    };
+    image.src = proxyUrl;
+
+    return () => {
+      cancelled = true;
+    };
+  }, [proxyUrl, retryKey]);
 
   if (!proxyUrl) {
     return (
@@ -52,8 +70,7 @@ export function MediaImage({ src, alt = '', title, className = '' }: MediaImageP
       <div className="relative max-w-full">
         {loadState === 'loading' ? (
           <div className="h-48 w-full animate-pulse rounded-[12px] bg-[var(--agyn-bg-light)]" />
-        ) : null}
-        {loadState === 'error' ? (
+        ) : loadState === 'error' ? (
           <div className="flex flex-col gap-2 rounded-[12px] border border-[var(--agyn-border-subtle)] bg-[var(--agyn-bg-light)] p-3">
             <span className="text-xs text-[var(--agyn-gray)]">
               {alt ? `Image failed to load: ${alt}` : 'Image failed to load.'}
@@ -73,12 +90,7 @@ export function MediaImage({ src, alt = '', title, className = '' }: MediaImageP
             alt={alt}
             title={title}
             loading="lazy"
-            onLoad={() => setLoadState('loaded')}
-            onError={() => setLoadState('error')}
-            className={cn(
-              'max-h-[360px] w-full rounded-[12px] border border-[var(--agyn-border-subtle)] object-contain',
-              loadState === 'loading' ? 'opacity-0' : 'opacity-100',
-            )}
+            className="max-h-[360px] w-full rounded-[12px] border border-[var(--agyn-border-subtle)] object-contain"
           />
         )}
       </div>

--- a/src/components/MediaImage.tsx
+++ b/src/components/MediaImage.tsx
@@ -51,7 +51,7 @@ export function MediaImage({ src, alt = '', title, className = '' }: MediaImageP
 
   if (!proxyUrl) {
     return (
-      <div className={cn('flex flex-col gap-2', className)} data-testid="media-image">
+      <div className={cn('flex flex-col gap-2', className)} data-testid="media-image" data-alt={alt}>
         <div
           className="rounded-[12px] border border-[var(--agyn-border-subtle)] bg-[var(--agyn-bg-light)] p-3 text-xs text-[var(--agyn-gray)]"
           data-testid="media-image-unavailable"
@@ -69,7 +69,7 @@ export function MediaImage({ src, alt = '', title, className = '' }: MediaImageP
   };
 
   return (
-    <div className={cn('flex flex-col gap-2', className)} data-testid="media-image">
+    <div className={cn('flex flex-col gap-2', className)} data-testid="media-image" data-alt={alt}>
       <div className="relative max-w-full">
         {loadState === 'loading' ? (
           <div

--- a/src/components/MediaVideo.tsx
+++ b/src/components/MediaVideo.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useMemo, useState } from 'react';
+import { buildDownloadUrl, buildProxyUrl } from '@/lib/media/proxy-url';
+import { cn } from '@/lib/utils';
+import { MediaDownloadLink } from './MediaDownloadLink';
+import { MediaFallback } from './MediaFallback';
+
+interface MediaVideoProps {
+  src: string;
+  label?: string;
+  className?: string;
+}
+
+export function MediaVideo({ src, label = 'Video', className = '' }: MediaVideoProps) {
+  const normalizedSrc = src.trim();
+  const proxyUrl = useMemo(() => (normalizedSrc ? buildProxyUrl(normalizedSrc) : null), [normalizedSrc]);
+  const downloadUrl = useMemo(() => (normalizedSrc ? buildDownloadUrl(normalizedSrc) : null), [normalizedSrc]);
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    setHasError(false);
+  }, [proxyUrl]);
+
+  if (!proxyUrl || hasError) {
+    return (
+      <MediaFallback
+        filename={label}
+        description={hasError ? 'Video failed to load.' : 'Video unavailable.'}
+        downloadUrl={downloadUrl}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-2', className)}>
+      <video
+        className="w-full rounded-[12px] border border-[var(--agyn-border-subtle)] bg-black"
+        controls
+        preload="metadata"
+        src={proxyUrl}
+        onError={() => setHasError(true)}
+      />
+      <MediaDownloadLink href={downloadUrl} />
+    </div>
+  );
+}

--- a/src/components/MediaVideo.tsx
+++ b/src/components/MediaVideo.tsx
@@ -22,23 +22,25 @@ export function MediaVideo({ src, label = 'Video', className = '' }: MediaVideoP
 
   if (!proxyUrl || hasError) {
     return (
-      <MediaFallback
-        filename={label}
-        description={hasError ? 'Video failed to load.' : 'Video unavailable.'}
-        downloadUrl={downloadUrl}
-        className={className}
-      />
+      <div className={cn('flex flex-col gap-2', className)} data-testid="media-video">
+        <MediaFallback
+          filename={label}
+          description={hasError ? 'Video failed to load.' : 'Video unavailable.'}
+          downloadUrl={downloadUrl}
+        />
+      </div>
     );
   }
 
   return (
-    <div className={cn('flex flex-col gap-2', className)}>
+    <div className={cn('flex flex-col gap-2', className)} data-testid="media-video">
       <video
         className="w-full rounded-[12px] border border-[var(--agyn-border-subtle)] bg-black"
         controls
         preload="metadata"
         src={proxyUrl}
         onError={() => setHasError(true)}
+        data-testid="media-video-element"
       />
       <MediaDownloadLink href={downloadUrl} />
     </div>

--- a/src/components/MessageAttachments.tsx
+++ b/src/components/MessageAttachments.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { useQueries } from '@tanstack/react-query';
 import { getFileMetadata } from '@/api/modules/files';
 import type { FileRecord } from '@/api/types/files';
@@ -50,10 +49,8 @@ const renderFileAttachment = (file: FileRecord) => {
 };
 
 export function MessageAttachments({ fileIds, className = '' }: MessageAttachmentsProps) {
-  const resolvedFileIds = useMemo(() => fileIds.filter(Boolean), [fileIds]);
-
   const queries = useQueries({
-    queries: resolvedFileIds.map((fileId) => ({
+    queries: fileIds.map((fileId) => ({
       queryKey: ['files', 'metadata', fileId],
       queryFn: () => getFileMetadata(fileId),
       staleTime: 5 * 60 * 1000,
@@ -61,13 +58,13 @@ export function MessageAttachments({ fileIds, className = '' }: MessageAttachmen
     })),
   });
 
-  if (resolvedFileIds.length === 0) {
+  if (fileIds.length === 0) {
     return null;
   }
 
   return (
     <div className={cn('flex flex-col gap-3', className)} data-testid="message-attachments">
-      {resolvedFileIds.map((fileId, index) => {
+      {fileIds.map((fileId, index) => {
         const query = queries[index];
         const fallbackUrl = buildDownloadUrl(buildAgynFileUrl(fileId));
 

--- a/src/components/MessageAttachments.tsx
+++ b/src/components/MessageAttachments.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from 'react';
+import { useQueries } from '@tanstack/react-query';
+import { getFileMetadata } from '@/api/modules/files';
+import type { FileRecord } from '@/api/types/files';
+import { buildDownloadUrl } from '@/lib/media/proxy-url';
+import { cn } from '@/lib/utils';
+import { MediaAudio } from './MediaAudio';
+import { MediaFallback } from './MediaFallback';
+import { MediaImage } from './MediaImage';
+import { MediaVideo } from './MediaVideo';
+
+interface MessageAttachmentsProps {
+  fileIds: string[];
+  className?: string;
+}
+
+const buildAgynFileUrl = (fileId: string) => `agyn://file/${fileId}`;
+
+const resolveMediaType = (contentType: string): 'image' | 'video' | 'audio' | 'other' => {
+  if (contentType.startsWith('image/')) return 'image';
+  if (contentType.startsWith('video/')) return 'video';
+  if (contentType.startsWith('audio/')) return 'audio';
+  return 'other';
+};
+
+const renderFileAttachment = (file: FileRecord) => {
+  const fileUrl = buildAgynFileUrl(file.id);
+  const mediaType = resolveMediaType(file.contentType);
+
+  if (mediaType === 'image') {
+    return <MediaImage src={fileUrl} alt={file.filename} />;
+  }
+
+  if (mediaType === 'video') {
+    return <MediaVideo src={fileUrl} label={file.filename} />;
+  }
+
+  if (mediaType === 'audio') {
+    return <MediaAudio src={fileUrl} label={file.filename} />;
+  }
+
+  return (
+    <MediaFallback
+      filename={file.filename}
+      contentType={file.contentType}
+      sizeBytes={file.sizeBytes}
+      downloadUrl={buildDownloadUrl(fileUrl)}
+    />
+  );
+};
+
+export function MessageAttachments({ fileIds, className = '' }: MessageAttachmentsProps) {
+  const resolvedFileIds = useMemo(() => fileIds.filter(Boolean), [fileIds]);
+
+  const queries = useQueries({
+    queries: resolvedFileIds.map((fileId) => ({
+      queryKey: ['files', 'metadata', fileId],
+      queryFn: () => getFileMetadata(fileId),
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
+    })),
+  });
+
+  if (resolvedFileIds.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)} data-testid="message-attachments">
+      {resolvedFileIds.map((fileId, index) => {
+        const query = queries[index];
+        const fallbackUrl = buildDownloadUrl(buildAgynFileUrl(fileId));
+
+        if (!query || query.isLoading) {
+          return (
+            <div
+              key={fileId}
+              className="h-24 w-full animate-pulse rounded-[12px] border border-[var(--agyn-border-subtle)] bg-[var(--agyn-bg-light)]"
+            />
+          );
+        }
+
+        if (query.isError || !query.data) {
+          return (
+            <MediaFallback
+              key={fileId}
+              filename={fileId}
+              description="Failed to load file metadata."
+              downloadUrl={fallbackUrl}
+            />
+          );
+        }
+
+        return (
+          <div key={fileId} className="min-w-0">
+            {renderFileAttachment(query.data)}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -64,6 +64,11 @@ describe('deriveMediaProxyUrl', () => {
     expect(deriveMediaProxyUrl()).toBeNull();
   });
 
+  it('returns null for IPv6 addresses', () => {
+    setLocation('http://[::1]:3000');
+    expect(deriveMediaProxyUrl()).toBeNull();
+  });
+
   it('returns null for bare domains', () => {
     setLocation('https://agyn.dev');
     expect(deriveMediaProxyUrl()).toBeNull();

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+type LocationStub = {
+  protocol: string;
+  hostname: string;
+  port: string;
+  origin: string;
+};
+
+type WindowStub = {
+  location: LocationStub;
+  __APP_CONFIG: { API_BASE_URL: string };
+};
+
+let deriveMediaProxyUrl: () => string | null;
+
+const windowStub: WindowStub = {
+  location: buildLocation('https://chat.agyn.dev'),
+  __APP_CONFIG: { API_BASE_URL: '/api' },
+};
+
+function buildLocation(url: string): LocationStub {
+  const parsed = new URL(url);
+  return {
+    protocol: parsed.protocol,
+    hostname: parsed.hostname,
+    port: parsed.port,
+    origin: parsed.origin,
+  };
+}
+
+function setLocation(url: string): void {
+  windowStub.location = buildLocation(url);
+}
+
+beforeAll(async () => {
+  vi.stubGlobal('window', windowStub as unknown as Window);
+  const mod = await import('./config');
+  deriveMediaProxyUrl = mod.deriveMediaProxyUrl;
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('deriveMediaProxyUrl', () => {
+  it('derives media proxy for subdomain hosts', () => {
+    setLocation('https://chat.agyn.dev');
+    expect(deriveMediaProxyUrl()).toBe('https://media.agyn.dev');
+  });
+
+  it('preserves ports when deriving', () => {
+    setLocation('https://chat.agyn.dev:1111');
+    expect(deriveMediaProxyUrl()).toBe('https://media.agyn.dev:1111');
+  });
+
+  it('returns null for localhost', () => {
+    setLocation('http://localhost');
+    expect(deriveMediaProxyUrl()).toBeNull();
+  });
+
+  it('returns null for IP addresses', () => {
+    setLocation('http://192.168.1.50');
+    expect(deriveMediaProxyUrl()).toBeNull();
+  });
+
+  it('returns null for bare domains', () => {
+    setLocation('https://agyn.dev');
+    expect(deriveMediaProxyUrl()).toBeNull();
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,7 +43,7 @@ export function deriveMediaProxyUrl(): string | null {
   const { protocol, hostname, port } = window.location;
 
   // Cannot derive from IP addresses
-  if (/^\d/.test(hostname) || hostname.startsWith('[')) return null;
+  if (/^\d/.test(hostname) || hostname.includes(':')) return null;
 
   const dotIndex = hostname.indexOf('.');
   if (dotIndex === -1) return null;
@@ -102,9 +102,12 @@ const apiBaseUrl = deriveBase(rawApiBase, { stripApi: true });
 const socketBaseUrl = deriveBase(rawApiBase, { stripApi: true });
 
 const rawMediaProxyUrl = readConfigValue('MEDIA_PROXY_URL', 'VITE_MEDIA_PROXY_URL');
-const mediaProxyUrl = rawMediaProxyUrl
-  ? deriveBase(rawMediaProxyUrl, { stripApi: false })
-  : deriveMediaProxyUrl();
+const mediaProxyUrl =
+  rawMediaProxyUrl === 'auto'
+    ? deriveMediaProxyUrl()
+    : rawMediaProxyUrl
+      ? deriveBase(rawMediaProxyUrl, { stripApi: false })
+      : null;
 
 const rawOidcAuthority = readConfigValue('OIDC_AUTHORITY', 'VITE_OIDC_AUTHORITY');
 const oidcEnabled = Boolean(rawOidcAuthority);

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,31 @@ type OidcConfig = OidcConfigEnabled | OidcConfigDisabled;
 
 const runtimeConfig: RuntimeConfig = typeof window !== 'undefined' ? (window.__APP_CONFIG ?? {}) : {};
 
+/**
+ * Derive media proxy base URL from the current page origin by replacing
+ * the first subdomain label with "media".
+ * Returns null when derivation is not possible (no subdomain, IP address, SSR, etc.).
+ */
+export function deriveMediaProxyUrl(): string | null {
+  if (typeof window === 'undefined') return null;
+
+  const { protocol, hostname, port } = window.location;
+
+  // Cannot derive from IP addresses
+  if (/^\d/.test(hostname) || hostname.startsWith('[')) return null;
+
+  const dotIndex = hostname.indexOf('.');
+  if (dotIndex === -1) return null;
+
+  // Require at least two dots to avoid bare domains (e.g. "agyn.dev" → ".dev" has no second dot)
+  const rest = hostname.slice(dotIndex); // ".agyn.dev"
+  if (!rest.includes('.', 1)) return null;
+
+  const derived = `media${rest}`;
+  const portSuffix = port ? `:${port}` : '';
+  return `${protocol}//${derived}${portSuffix}`;
+}
+
 function readConfigValue(runtimeKey: keyof RuntimeConfig, envKey: keyof ViteEnv): string | null {
   const runtimeValue = runtimeConfig[runtimeKey];
   if (typeof runtimeValue === 'string' && runtimeValue.trim()) return runtimeValue.trim();
@@ -77,7 +102,9 @@ const apiBaseUrl = deriveBase(rawApiBase, { stripApi: true });
 const socketBaseUrl = deriveBase(rawApiBase, { stripApi: true });
 
 const rawMediaProxyUrl = readConfigValue('MEDIA_PROXY_URL', 'VITE_MEDIA_PROXY_URL');
-const mediaProxyUrl = rawMediaProxyUrl ? deriveBase(rawMediaProxyUrl, { stripApi: false }) : null;
+const mediaProxyUrl = rawMediaProxyUrl
+  ? deriveBase(rawMediaProxyUrl, { stripApi: false })
+  : deriveMediaProxyUrl();
 
 const rawOidcAuthority = readConfigValue('OIDC_AUTHORITY', 'VITE_OIDC_AUTHORITY');
 const oidcEnabled = Boolean(rawOidcAuthority);

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@
 
 type RuntimeConfig = {
   API_BASE_URL?: string;
+  MEDIA_PROXY_URL?: string;
   OIDC_AUTHORITY?: string;
   OIDC_CLIENT_ID?: string;
   OIDC_SCOPE?: string;
@@ -10,6 +11,7 @@ type RuntimeConfig = {
 
 type ViteEnv = {
   VITE_API_BASE_URL?: string;
+  VITE_MEDIA_PROXY_URL?: string;
   VITE_OIDC_AUTHORITY?: string;
   VITE_OIDC_CLIENT_ID?: string;
   VITE_OIDC_SCOPE?: string;
@@ -74,6 +76,9 @@ const rawApiBase = requireConfig('API_BASE_URL', readConfigValue('API_BASE_URL',
 const apiBaseUrl = deriveBase(rawApiBase, { stripApi: true });
 const socketBaseUrl = deriveBase(rawApiBase, { stripApi: true });
 
+const rawMediaProxyUrl = readConfigValue('MEDIA_PROXY_URL', 'VITE_MEDIA_PROXY_URL');
+const mediaProxyUrl = rawMediaProxyUrl ? deriveBase(rawMediaProxyUrl, { stripApi: false }) : null;
+
 const rawOidcAuthority = readConfigValue('OIDC_AUTHORITY', 'VITE_OIDC_AUTHORITY');
 const oidcEnabled = Boolean(rawOidcAuthority);
 
@@ -88,6 +93,7 @@ export const oidcConfig: OidcConfig = oidcEnabled
 
 export const config = {
   apiBaseUrl,
+  mediaProxyUrl,
   socketBaseUrl,
 };
 

--- a/src/lib/markdown/sanitize.ts
+++ b/src/lib/markdown/sanitize.ts
@@ -14,13 +14,18 @@ const allowedTagNames: Schema['tagNames'] = [
   'h5',
   'h6',
   'hr',
+  'img',
   'li',
   'ol',
+  'picture',
   'p',
   'pre',
   'strong',
   'u',
   'ul',
+  'video',
+  'audio',
+  'source',
   'table',
   'thead',
   'tbody',
@@ -43,6 +48,7 @@ export const markdownSanitizeSchema: Schema = {
     code: [
       ['className', /^language-[\w-]+$/],
     ],
+    img: ['src', 'alt', 'title', 'width', 'height', 'loading'],
     ol: [
       ['start', /^-?\d+$/],
       ['type', '1', 'a', 'A', 'i', 'I'],
@@ -51,10 +57,14 @@ export const markdownSanitizeSchema: Schema = {
     li: [
       ['value', /^-?\d+$/],
     ],
+    video: ['src', 'controls', 'preload', 'width', 'height', 'poster'],
+    audio: ['src', 'controls', 'preload'],
+    source: ['src', 'type'],
     th: ['align'],
     td: ['align'],
   },
   protocols: {
     href: [...allowedProtocols],
+    src: ['http', 'https', 'agyn'],
   },
 };

--- a/src/lib/media/proxy-url.test.ts
+++ b/src/lib/media/proxy-url.test.ts
@@ -28,10 +28,28 @@ describe('proxy-url', () => {
     expect(result).toBe('https://media.agyn.dev/proxy?url=agyn%3A%2F%2Ffile%2F1234');
   });
 
+  it('builds download url for https links', async () => {
+    const { buildDownloadUrl } = await loadProxyModule('https://media.agyn.dev');
+    const result = buildDownloadUrl('https://example.com/archive.zip');
+    expect(result).toBe('https://media.agyn.dev/proxy?url=https%3A%2F%2Fexample.com%2Farchive.zip');
+  });
+
   it('returns null when media proxy is missing', async () => {
     const { buildProxyUrl } = await loadProxyModule(null);
     const result = buildProxyUrl('https://example.com/image.png', { size: 800 });
     expect(result).toBeNull();
+  });
+
+  it('ignores empty or whitespace input', async () => {
+    const { buildProxyUrl, buildDownloadUrl } = await loadProxyModule('https://media.agyn.dev');
+    expect(buildProxyUrl('   ', { size: 800 })).toBeNull();
+    expect(buildDownloadUrl('')).toBeNull();
+  });
+
+  it('skips invalid sizes', async () => {
+    const { buildProxyUrl } = await loadProxyModule('https://media.agyn.dev');
+    const result = buildProxyUrl('https://example.com/image.png', { size: 0 });
+    expect(result).toBe('https://media.agyn.dev/proxy?url=https%3A%2F%2Fexample.com%2Fimage.png');
   });
 
   it('parses agyn file ids', async () => {
@@ -40,6 +58,8 @@ describe('proxy-url', () => {
     expect(parseAgynFileId('agyn://file/550e8400-e29b-41d4-a716-446655440000')).toBe(
       '550e8400-e29b-41d4-a716-446655440000',
     );
+    expect(parseAgynFileId('agyn://file')).toBeNull();
+    expect(parseAgynFileId('agyn://files/1234')).toBeNull();
     expect(isAgynFileUrl('https://example.com/file')).toBe(false);
     expect(parseAgynFileId('https://example.com/file')).toBeNull();
   });

--- a/src/lib/media/proxy-url.test.ts
+++ b/src/lib/media/proxy-url.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const loadProxyModule = async (mediaProxyUrl: string | null) => {
+  vi.resetModules();
+  vi.doMock('@/config', () => ({
+    config: {
+      mediaProxyUrl,
+    },
+  }));
+  return import('./proxy-url');
+};
+
+afterEach(() => {
+  vi.resetModules();
+  vi.unmock('@/config');
+});
+
+describe('proxy-url', () => {
+  it('builds proxy url with size for external urls', async () => {
+    const { buildProxyUrl } = await loadProxyModule('https://media.agyn.dev');
+    const result = buildProxyUrl('https://example.com/image.png', { size: 800 });
+    expect(result).toBe('https://media.agyn.dev/proxy?url=https%3A%2F%2Fexample.com%2Fimage.png&size=800');
+  });
+
+  it('builds proxy url for agyn files without size', async () => {
+    const { buildDownloadUrl } = await loadProxyModule('https://media.agyn.dev');
+    const result = buildDownloadUrl('agyn://file/1234');
+    expect(result).toBe('https://media.agyn.dev/proxy?url=agyn%3A%2F%2Ffile%2F1234');
+  });
+
+  it('returns null when media proxy is missing', async () => {
+    const { buildProxyUrl } = await loadProxyModule(null);
+    const result = buildProxyUrl('https://example.com/image.png', { size: 800 });
+    expect(result).toBeNull();
+  });
+
+  it('parses agyn file ids', async () => {
+    const { isAgynFileUrl, parseAgynFileId } = await loadProxyModule('https://media.agyn.dev');
+    expect(isAgynFileUrl('agyn://file/550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+    expect(parseAgynFileId('agyn://file/550e8400-e29b-41d4-a716-446655440000')).toBe(
+      '550e8400-e29b-41d4-a716-446655440000',
+    );
+    expect(isAgynFileUrl('https://example.com/file')).toBe(false);
+    expect(parseAgynFileId('https://example.com/file')).toBeNull();
+  });
+});

--- a/src/lib/media/proxy-url.ts
+++ b/src/lib/media/proxy-url.ts
@@ -1,0 +1,72 @@
+import { config } from '@/config';
+
+const AGYN_FILE_PROTOCOL = 'agyn:';
+const AGYN_FILE_HOST = 'file';
+
+export const INLINE_IMAGE_MAX_SIZE = 800;
+
+type BuildProxyOptions = {
+  size?: number | null;
+};
+
+const normalizeInput = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed;
+};
+
+const resolveMediaProxyBase = (): string | null => {
+  const base = config.mediaProxyUrl;
+  if (typeof base !== 'string') return null;
+  const trimmed = base.trim();
+  if (!trimmed) return null;
+  return trimmed.replace(/\/+$/, '');
+};
+
+const normalizeSize = (size?: number | null): string | null => {
+  if (typeof size !== 'number' || !Number.isFinite(size) || size <= 0) return null;
+  return Math.round(size).toString();
+};
+
+export function buildProxyUrl(originalUrl: string, options: BuildProxyOptions = {}): string | null {
+  const base = resolveMediaProxyBase();
+  const normalizedOriginal = normalizeInput(originalUrl);
+  if (!base || !normalizedOriginal) return null;
+
+  const proxyBase = `${base}/proxy`;
+  const url = new URL(proxyBase);
+  url.searchParams.set('url', normalizedOriginal);
+
+  const size = normalizeSize(options.size);
+  if (size) {
+    url.searchParams.set('size', size);
+  }
+
+  return url.toString();
+}
+
+export function buildDownloadUrl(originalUrl: string): string | null {
+  return buildProxyUrl(originalUrl);
+}
+
+export function parseAgynFileId(value: string): string | null {
+  const normalized = normalizeInput(value);
+  if (!normalized) return null;
+
+  let url: URL;
+  try {
+    url = new URL(normalized);
+  } catch (_error) {
+    return null;
+  }
+
+  if (url.protocol !== AGYN_FILE_PROTOCOL) return null;
+  if (url.hostname !== AGYN_FILE_HOST) return null;
+
+  const path = url.pathname.replace(/^\/+/, '').replace(/\/+$/, '');
+  return path ? path : null;
+}
+
+export function isAgynFileUrl(value: string): boolean {
+  return parseAgynFileId(value) !== null;
+}

--- a/src/lib/media/proxy-url.ts
+++ b/src/lib/media/proxy-url.ts
@@ -17,14 +17,12 @@ const normalizeInput = (value: string): string | null => {
 
 const resolveMediaProxyBase = (): string | null => {
   const base = config.mediaProxyUrl;
-  if (typeof base !== 'string') return null;
-  const trimmed = base.trim();
-  if (!trimmed) return null;
-  return trimmed.replace(/\/+$/, '');
+  if (!base) return null;
+  return base.replace(/\/+$/, '');
 };
 
 const normalizeSize = (size?: number | null): string | null => {
-  if (typeof size !== 'number' || !Number.isFinite(size) || size <= 0) return null;
+  if (size == null || !Number.isFinite(size) || size <= 0) return null;
   return Math.round(size).toString();
 };
 

--- a/src/lib/media/sw-registration.ts
+++ b/src/lib/media/sw-registration.ts
@@ -2,6 +2,7 @@ import { config } from '@/config';
 import { getAccessToken, userManager } from '@/auth';
 
 const TOKEN_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const SW_SCRIPT_URL = '/sw.js';
 
 type SetTokenMessage = {
   type: 'SET_TOKEN';
@@ -61,7 +62,10 @@ const sendTokenUpdate = async (
 export async function registerMediaServiceWorker(): Promise<void> {
   if (typeof window === 'undefined') return;
   if (!('serviceWorker' in navigator)) return;
-  if (!config.mediaProxyUrl) return;
+  if (!config.mediaProxyUrl) {
+    void unregisterStaleServiceWorker();
+    return;
+  }
 
   const mediaProxyOrigin = resolveMediaProxyOrigin(config.mediaProxyUrl);
   if (!mediaProxyOrigin) {
@@ -71,7 +75,7 @@ export async function registerMediaServiceWorker(): Promise<void> {
 
   let registration: ServiceWorkerRegistration;
   try {
-    registration = await navigator.serviceWorker.register('/sw.js');
+    registration = await navigator.serviceWorker.register(SW_SCRIPT_URL);
   } catch (error) {
     console.warn('[media] failed to register service worker', error);
     return;
@@ -95,4 +99,15 @@ export async function registerMediaServiceWorker(): Promise<void> {
   window.setInterval(() => {
     void sendTokenUpdate(registration, mediaProxyOrigin);
   }, TOKEN_REFRESH_INTERVAL_MS);
+}
+
+async function unregisterStaleServiceWorker(): Promise<void> {
+  try {
+    const registration = await navigator.serviceWorker.getRegistration(SW_SCRIPT_URL);
+    if (registration) {
+      await registration.unregister();
+    }
+  } catch (_error) {
+    // Best-effort cleanup; ignore failures.
+  }
 }

--- a/src/lib/media/sw-registration.ts
+++ b/src/lib/media/sw-registration.ts
@@ -1,0 +1,98 @@
+import { config } from '@/config';
+import { getAccessToken, userManager } from '@/auth';
+
+const TOKEN_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
+type SetTokenMessage = {
+  type: 'SET_TOKEN';
+  token: string;
+  mediaProxyOrigin: string;
+};
+
+type ClearTokenMessage = {
+  type: 'CLEAR_TOKEN';
+};
+
+type MediaProxyMessage = SetTokenMessage | ClearTokenMessage;
+
+const resolveMediaProxyOrigin = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    return new URL(trimmed).origin;
+  } catch (_error) {
+    return null;
+  }
+};
+
+const postMessageToWorker = (
+  registration: ServiceWorkerRegistration,
+  message: MediaProxyMessage,
+): void => {
+  const controller = navigator.serviceWorker.controller;
+  if (controller) {
+    controller.postMessage(message);
+    return;
+  }
+
+  const active = registration.active;
+  if (active) {
+    active.postMessage(message);
+  }
+};
+
+const sendTokenUpdate = async (
+  registration: ServiceWorkerRegistration,
+  mediaProxyOrigin: string,
+): Promise<void> => {
+  const token = await getAccessToken();
+  if (!token) {
+    postMessageToWorker(registration, { type: 'CLEAR_TOKEN' });
+    return;
+  }
+
+  postMessageToWorker(registration, {
+    type: 'SET_TOKEN',
+    token,
+    mediaProxyOrigin,
+  });
+};
+
+export async function registerMediaServiceWorker(): Promise<void> {
+  if (typeof window === 'undefined') return;
+  if (!('serviceWorker' in navigator)) return;
+  if (!config.mediaProxyUrl) return;
+
+  const mediaProxyOrigin = resolveMediaProxyOrigin(config.mediaProxyUrl);
+  if (!mediaProxyOrigin) {
+    console.warn('[media] invalid MEDIA_PROXY_URL; service worker disabled');
+    return;
+  }
+
+  let registration: ServiceWorkerRegistration;
+  try {
+    registration = await navigator.serviceWorker.register('/sw.js');
+  } catch (error) {
+    console.warn('[media] failed to register service worker', error);
+    return;
+  }
+
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    void sendTokenUpdate(registration, mediaProxyOrigin);
+  });
+
+  void sendTokenUpdate(registration, mediaProxyOrigin);
+
+  if (userManager) {
+    userManager.events.addUserLoaded(() => {
+      void sendTokenUpdate(registration, mediaProxyOrigin);
+    });
+    userManager.events.addUserSignedOut(() => {
+      postMessageToWorker(registration, { type: 'CLEAR_TOKEN' });
+    });
+  }
+
+  window.setInterval(() => {
+    void sendTokenUpdate(registration, mediaProxyOrigin);
+  }, TOKEN_REFRESH_INTERVAL_MS);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthGate } from '@/auth';
+import { registerMediaServiceWorker } from '@/lib/media/sw-registration';
 import App from './App';
 import './index.css';
 import { UserProvider } from './user/UserProvider';
@@ -25,3 +26,5 @@ createRoot(document.getElementById('root')!).render(
     </BrowserRouter>
   </StrictMode>,
 );
+
+void registerMediaServiceWorker();

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -4,6 +4,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { ChatListItem } from '@/components/ChatListItem';
 import type { ChatMessage, ChatQueuedMessageData, ChatReminderData, ChatRun } from '@/components/Chat';
 import { MarkdownContent } from '@/components/MarkdownContent';
+import { MessageAttachments } from '@/components/MessageAttachments';
+import { formatDuration } from '@/components/agents/runTimelineFormatting';
 import ChatsScreen from '@/components/screens/ChatsScreen';
 import { notifyError } from '@/lib/notify';
 import { useUser } from '@/user/user.runtime';
@@ -466,14 +468,11 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
           : agentIdSet.has(message.senderId)
             ? 'assistant'
             : 'user';
-        const attachmentCount = message.fileIds.length;
         const content = (
           <div className="space-y-1">
             <MarkdownContent content={message.body} />
-            {attachmentCount > 0 ? (
-              <p className="text-xs text-[var(--agyn-gray)]">
-                {attachmentCount} attachment{attachmentCount === 1 ? '' : 's'}
-              </p>
+            {message.fileIds.length > 0 ? (
+              <MessageAttachments fileIds={message.fileIds} />
             ) : null}
           </div>
         );

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -5,7 +5,6 @@ import type { ChatListItem } from '@/components/ChatListItem';
 import type { ChatMessage, ChatQueuedMessageData, ChatReminderData, ChatRun } from '@/components/Chat';
 import { MarkdownContent } from '@/components/MarkdownContent';
 import { MessageAttachments } from '@/components/MessageAttachments';
-import { formatDuration } from '@/components/agents/runTimelineFormatting';
 import ChatsScreen from '@/components/screens/ChatsScreen';
 import { notifyError } from '@/lib/notify';
 import { useUser } from '@/user/user.runtime';

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -10,15 +10,12 @@ type ClearTokenMessage = {
 
 type MediaProxyMessage = SetTokenMessage | ClearTokenMessage;
 
-let accessToken: string | null = null;
-let mediaProxyOrigin: string | null = null;
-
+// Boundary: validate and normalize incoming messages.
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return Boolean(value) && typeof value === 'object';
 };
 
-const parseSetTokenMessage = (value: unknown): SetTokenMessage | null => {
-  if (!isRecord(value)) return null;
+const parseSetTokenMessage = (value: Record<string, unknown>): SetTokenMessage | null => {
   if (value.type !== 'SET_TOKEN') return null;
 
   const token = typeof value.token === 'string' ? value.token.trim() : '';
@@ -35,9 +32,19 @@ const parseSetTokenMessage = (value: unknown): SetTokenMessage | null => {
   return { type: 'SET_TOKEN', token, mediaProxyOrigin: normalizedOrigin };
 };
 
-const isClearTokenMessage = (value: unknown): value is ClearTokenMessage => {
-  return isRecord(value) && value.type === 'CLEAR_TOKEN';
+const parseClearTokenMessage = (value: Record<string, unknown>): ClearTokenMessage | null => {
+  if (value.type !== 'CLEAR_TOKEN') return null;
+  return { type: 'CLEAR_TOKEN' };
 };
+
+const parseMediaProxyMessage = (value: unknown): MediaProxyMessage | null => {
+  if (!isRecord(value)) return null;
+  return parseSetTokenMessage(value) ?? parseClearTokenMessage(value);
+};
+
+// Internal: strict logic based on validated inputs.
+let accessToken: string | null = null;
+let mediaProxyOrigin: string | null = null;
 
 const handleMessage = (message: MediaProxyMessage): void => {
   if (message.type === 'CLEAR_TOKEN') {
@@ -69,6 +76,13 @@ const buildAuthorizedRequest = (request: Request, token: string): Request => {
   });
 };
 
+const buildUnauthorizedResponse = () =>
+  new Response('Unauthorized', {
+    status: 401,
+    statusText: 'Unauthorized',
+    headers: { 'Content-Type': 'text/plain' },
+  });
+
 self.addEventListener('install', (event) => {
   event.waitUntil(self.skipWaiting());
 });
@@ -78,13 +92,9 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('message', (event) => {
-  const setMessage = parseSetTokenMessage(event.data);
-  if (setMessage) {
-    handleMessage(setMessage);
-    return;
-  }
-  if (isClearTokenMessage(event.data)) {
-    handleMessage({ type: 'CLEAR_TOKEN' });
+  const message = parseMediaProxyMessage(event.data);
+  if (message) {
+    handleMessage(message);
   }
 });
 
@@ -92,7 +102,7 @@ self.addEventListener('fetch', (event) => {
   if (!shouldProxyRequest(event.request)) return;
 
   if (!accessToken) {
-    event.respondWith(fetch(event.request));
+    event.respondWith(buildUnauthorizedResponse());
     return;
   }
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,0 +1,101 @@
+type SetTokenMessage = {
+  type: 'SET_TOKEN';
+  token: string;
+  mediaProxyOrigin: string;
+};
+
+type ClearTokenMessage = {
+  type: 'CLEAR_TOKEN';
+};
+
+type MediaProxyMessage = SetTokenMessage | ClearTokenMessage;
+
+let accessToken: string | null = null;
+let mediaProxyOrigin: string | null = null;
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return Boolean(value) && typeof value === 'object';
+};
+
+const parseSetTokenMessage = (value: unknown): SetTokenMessage | null => {
+  if (!isRecord(value)) return null;
+  if (value.type !== 'SET_TOKEN') return null;
+
+  const token = typeof value.token === 'string' ? value.token.trim() : '';
+  const origin = typeof value.mediaProxyOrigin === 'string' ? value.mediaProxyOrigin.trim() : '';
+  if (!token || !origin) return null;
+
+  let normalizedOrigin = '';
+  try {
+    normalizedOrigin = new URL(origin).origin;
+  } catch (_error) {
+    return null;
+  }
+
+  return { type: 'SET_TOKEN', token, mediaProxyOrigin: normalizedOrigin };
+};
+
+const isClearTokenMessage = (value: unknown): value is ClearTokenMessage => {
+  return isRecord(value) && value.type === 'CLEAR_TOKEN';
+};
+
+const handleMessage = (message: MediaProxyMessage): void => {
+  if (message.type === 'CLEAR_TOKEN') {
+    accessToken = null;
+    mediaProxyOrigin = null;
+    return;
+  }
+
+  accessToken = message.token;
+  mediaProxyOrigin = message.mediaProxyOrigin;
+};
+
+const shouldProxyRequest = (request: Request): boolean => {
+  if (!mediaProxyOrigin) return false;
+  try {
+    return new URL(request.url).origin === mediaProxyOrigin;
+  } catch (_error) {
+    return false;
+  }
+};
+
+const buildAuthorizedRequest = (request: Request, token: string): Request => {
+  const headers = new Headers(request.headers);
+  headers.set('Authorization', `Bearer ${token}`);
+  return new Request(request, {
+    headers,
+    mode: 'cors',
+    credentials: request.credentials,
+  });
+};
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', (event) => {
+  const setMessage = parseSetTokenMessage(event.data);
+  if (setMessage) {
+    handleMessage(setMessage);
+    return;
+  }
+  if (isClearTokenMessage(event.data)) {
+    handleMessage({ type: 'CLEAR_TOKEN' });
+  }
+});
+
+self.addEventListener('fetch', (event) => {
+  if (!shouldProxyRequest(event.request)) return;
+
+  if (!accessToken) {
+    event.respondWith(fetch(event.request));
+    return;
+  }
+
+  const authorizedRequest = buildAuthorizedRequest(event.request, accessToken);
+  event.respondWith(fetch(authorizedRequest));
+});

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_MEDIA_PROXY_URL?: string;
   readonly VITE_OIDC_AUTHORITY?: string;
   readonly VITE_OIDC_CLIENT_ID?: string;
   readonly VITE_OIDC_SCOPE?: string;
@@ -14,6 +15,7 @@ interface ImportMeta {
 interface Window {
   __APP_CONFIG?: {
     API_BASE_URL?: string;
+    MEDIA_PROXY_URL?: string;
     OIDC_AUTHORITY?: string;
     OIDC_CLIENT_ID?: string;
     OIDC_SCOPE?: string;

--- a/test/e2e/file-upload.spec.ts
+++ b/test/e2e/file-upload.spec.ts
@@ -59,7 +59,9 @@ test('uploads a file and sends a message with attachment', async ({ page }) => {
 
   const messageItem = page.getByTestId('chat-message').filter({ hasText: message });
   await expect(messageItem).toBeVisible({ timeout: 15000 });
-  await expect(messageItem).toContainText('1 attachment');
+  const attachmentCard = messageItem.getByTestId('message-attachments');
+  await expect(attachmentCard).toContainText('test-upload.txt', { timeout: 15000 });
+  await expect(attachmentCard).toContainText('text/plain');
 
   await argosScreenshot(page, 'file-upload-message-sent');
 });

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -51,7 +51,7 @@ async function expectInlineImage(
   messageItem: Locator,
   altText: string,
 ): Promise<void> {
-  const image = messageItem.getByTestId('media-image');
+  const image = messageItem.getByTestId('media-image').filter({ hasText: altText });
   await expect(image).toBeVisible({ timeout: 15000 });
 
   const resolved = image.locator(

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -135,7 +135,20 @@ test('renders inline image with agyn:// protocol URL', async ({ page }) => {
   const message = `${anchor}: Attached image: ![project diagram](agyn://file/550e8400-e29b-41d4-a716-446655440000)`;
 
   const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
-  await expectInlineImage(messageItem, 'project diagram', hasProxy);
+  const image = messageItem.getByTestId('media-image');
+  await expect(image).toBeVisible({ timeout: 15000 });
+
+  if (hasProxy) {
+    const state = image.locator(
+      '[data-testid="media-image-loading"], [data-testid="media-image-element"], [data-testid="media-image-error"]',
+    );
+    await expect(state.first()).toBeVisible({ timeout: 15000 });
+    return;
+  }
+
+  const unavailable = image.getByTestId('media-image-unavailable');
+  await expect(unavailable).toBeVisible({ timeout: 15000 });
+  await expect(unavailable).toContainText('project diagram');
 });
 
 test('renders multiple inline images in a single message', async ({ page }) => {

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -65,16 +65,9 @@ async function expectInlineImage(
   await expect(image).toBeVisible({ timeout: 15000 });
 
   if (hasProxy) {
-    const resolved = image.locator(
-      '[data-testid="media-image-element"], [data-testid="media-image-error"]',
-    );
-    await expect(resolved.first()).toBeVisible({ timeout: 15000 });
     const element = image.getByTestId('media-image-element');
-    if (await element.count()) {
-      await expect(element).toHaveAttribute('alt', altText);
-    } else {
-      await expect(image.getByTestId('media-image-error')).toContainText(altText);
-    }
+    await expect(element).toBeVisible({ timeout: 15000 });
+    await expect(element).toHaveAttribute('alt', altText);
     return;
   }
 
@@ -122,7 +115,7 @@ async function expectInlineAudio(messageItem: Locator, hasProxy: boolean): Promi
 test('renders inline image from markdown with external URL', async ({ page }) => {
   const now = Date.now();
   const anchor = `Inline image external ${now}`;
-  const message = `${anchor}: Here is a photo: ![a sunset over the ocean](https://example.com/photo.png)`;
+  const message = `${anchor}: Here is a photo: ![a sunset over the ocean](https://httpbin.org/image/png)`;
 
   const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
   await expectInlineImage(messageItem, 'a sunset over the ocean', hasProxy);
@@ -154,10 +147,16 @@ test('renders inline image with agyn:// protocol URL', async ({ page }) => {
 test('renders multiple inline images in a single message', async ({ page }) => {
   const now = Date.now();
   const anchor = `Inline image gallery ${now}`;
-  const message = `${anchor}: ![diagram one](https://example.com/one.png) ![diagram two](https://example.com/two.png) ![diagram three](https://example.com/three.png)`;
+  const message = `${anchor}: ![diagram one](https://httpbin.org/image/png) ![diagram two](https://httpbin.org/image/jpeg) ![diagram three](https://httpbin.org/image/svg)`;
 
-  const { messageItem } = await openChatWithMessage(page, message, anchor);
+  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
   await expect(messageItem.getByTestId('media-image')).toHaveCount(3);
+
+  if (hasProxy) {
+    await expect(messageItem.getByTestId('media-image-element')).toHaveCount(3, { timeout: 15000 });
+  } else {
+    await expect(messageItem.getByTestId('media-image-unavailable')).toHaveCount(3, { timeout: 15000 });
+  }
 });
 
 test('renders video when alt text is "video"', async ({ page }) => {
@@ -181,7 +180,7 @@ test('renders audio when alt text is "audio"', async ({ page }) => {
 test('renders mixed media types in one message', async ({ page }) => {
   const now = Date.now();
   const anchor = `Inline mixed media ${now}`;
-  const message = `${anchor}: ![diagram](https://example.com/diagram.png) ![video](https://example.com/demo.mp4) ![audio](https://example.com/podcast.mp3)`;
+  const message = `${anchor}: ![diagram](https://httpbin.org/image/png) ![video](https://example.com/demo.mp4) ![audio](https://example.com/podcast.mp3)`;
 
   const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
   await expect(messageItem.getByTestId('media-image')).toHaveCount(1);
@@ -197,7 +196,7 @@ test('message with markdown text and inline image renders both', async ({ page }
   const now = Date.now();
   const heading = `Release update ${now}`;
   const anchor = heading;
-  const message = `# ${heading}\n\nThis is **important**: ![release screenshot](https://example.com/release.png)\n\nFinal notes.`;
+  const message = `# ${heading}\n\nThis is **important**: ![release screenshot](https://httpbin.org/image/png)\n\nFinal notes.`;
 
   const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
   await expect(messageItem.getByRole('heading', { name: heading })).toBeVisible({ timeout: 15000 });

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -54,9 +54,15 @@ async function expectInlineImage(
   const image = messageItem.getByTestId('media-image');
   await expect(image).toBeVisible({ timeout: 15000 });
 
+  const resolved = image.locator(
+    '[data-testid="media-image-element"], [data-testid="media-image-error"]',
+  );
+  await expect(resolved.first()).toBeVisible({ timeout: 15000 });
+
   const element = image.getByTestId('media-image-element');
-  await expect(element).toBeVisible({ timeout: 15000 });
-  await expect(element).toHaveAttribute('alt', altText);
+  if (await element.count()) {
+    await expect(element).toHaveAttribute('alt', altText);
+  }
 }
 
 async function expectInlineVideo(messageItem: Locator): Promise<void> {
@@ -93,7 +99,7 @@ test('renders inline image with agyn:// protocol URL', async ({ page }) => {
   await expect(image).toBeVisible({ timeout: 15000 });
 
   const state = image.locator(
-    '[data-testid="media-image-loading"], [data-testid="media-image-error"]',
+    '[data-testid="media-image-loading"], [data-testid="media-image-element"], [data-testid="media-image-error"]',
   );
   await expect(state.first()).toBeVisible({ timeout: 15000 });
 });

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -22,19 +22,11 @@ function buildAgentOptions(organizationId: string, name: string) {
   };
 }
 
-async function getMediaProxyUrl(page: Page): Promise<string | null> {
-  return page.evaluate(() => {
-    const config = (window as { __APP_CONFIG?: { MEDIA_PROXY_URL?: unknown } }).__APP_CONFIG;
-    const value = config?.MEDIA_PROXY_URL;
-    return typeof value === 'string' && value.trim() ? value.trim() : null;
-  });
-}
-
 async function openChatWithMessage(
   page: Page,
   message: string,
   anchorText: string,
-): Promise<{ messageItem: Locator; hasProxy: boolean }> {
+): Promise<Locator> {
   const now = Date.now();
   const organizationId = await createOrganization(page, `e2e-org-inline-media-${now}`);
   const agentId = await createAgent(page, buildAgentOptions(organizationId, `e2e-agent-inline-media-${now}`));
@@ -52,64 +44,33 @@ async function openChatWithMessage(
   const messageItem = page.getByTestId('chat-message').filter({ hasText: anchorText });
   await expect(messageItem).toBeVisible({ timeout: 15000 });
 
-  const hasProxy = Boolean(await getMediaProxyUrl(page));
-  return { messageItem, hasProxy };
+  return messageItem;
 }
 
 async function expectInlineImage(
   messageItem: Locator,
   altText: string,
-  hasProxy: boolean,
 ): Promise<void> {
   const image = messageItem.getByTestId('media-image');
   await expect(image).toBeVisible({ timeout: 15000 });
 
-  if (hasProxy) {
-    const element = image.getByTestId('media-image-element');
-    await expect(element).toBeVisible({ timeout: 15000 });
-    await expect(element).toHaveAttribute('alt', altText);
-    return;
-  }
-
-  const unavailable = image.getByTestId('media-image-unavailable');
-  await expect(unavailable).toBeVisible({ timeout: 15000 });
-  await expect(unavailable).toContainText(altText);
+  const element = image.getByTestId('media-image-element');
+  await expect(element).toBeVisible({ timeout: 15000 });
+  await expect(element).toHaveAttribute('alt', altText);
 }
 
-async function expectInlineMediaFallback(
-  root: Locator,
-  elementTestId: string,
-  hasProxy: boolean,
-): Promise<void> {
-  const element = root.getByTestId(elementTestId);
-  const fallback = root.getByTestId('media-fallback');
-  const resolved = root.locator(
-    `[data-testid="${elementTestId}"], [data-testid="media-fallback"]`,
-  );
-  await expect(resolved.first()).toBeVisible({ timeout: 15000 });
-
-  if (!hasProxy) {
-    await expect(fallback).toBeVisible({ timeout: 15000 });
-    return;
-  }
-
-  if (await element.count()) {
-    await expect(element).toBeVisible({ timeout: 15000 });
-  } else {
-    await expect(fallback).toBeVisible({ timeout: 15000 });
-  }
-}
-
-async function expectInlineVideo(messageItem: Locator, hasProxy: boolean): Promise<void> {
+async function expectInlineVideo(messageItem: Locator): Promise<void> {
   const video = messageItem.getByTestId('media-video');
   await expect(video).toBeVisible({ timeout: 15000 });
-  await expectInlineMediaFallback(video, 'media-video-element', hasProxy);
+  const resolved = video.locator('[data-testid="media-video-element"], [data-testid="media-fallback"]');
+  await expect(resolved.first()).toBeVisible({ timeout: 15000 });
 }
 
-async function expectInlineAudio(messageItem: Locator, hasProxy: boolean): Promise<void> {
+async function expectInlineAudio(messageItem: Locator): Promise<void> {
   const audio = messageItem.getByTestId('media-audio');
   await expect(audio).toBeVisible({ timeout: 15000 });
-  await expectInlineMediaFallback(audio, 'media-audio-element', hasProxy);
+  const resolved = audio.locator('[data-testid="media-audio-element"], [data-testid="media-fallback"]');
+  await expect(resolved.first()).toBeVisible({ timeout: 15000 });
 }
 
 test('renders inline image from markdown with external URL', async ({ page }) => {
@@ -117,8 +78,8 @@ test('renders inline image from markdown with external URL', async ({ page }) =>
   const anchor = `Inline image external ${now}`;
   const message = `${anchor}: Here is a photo: ![a sunset over the ocean](https://httpbin.org/image/png)`;
 
-  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
-  await expectInlineImage(messageItem, 'a sunset over the ocean', hasProxy);
+  const messageItem = await openChatWithMessage(page, message, anchor);
+  await expectInlineImage(messageItem, 'a sunset over the ocean');
   await argosScreenshot(page, 'inline-media-image-external');
 });
 
@@ -127,21 +88,14 @@ test('renders inline image with agyn:// protocol URL', async ({ page }) => {
   const anchor = `Inline image agyn ${now}`;
   const message = `${anchor}: Attached image: ![project diagram](agyn://file/550e8400-e29b-41d4-a716-446655440000)`;
 
-  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
+  const messageItem = await openChatWithMessage(page, message, anchor);
   const image = messageItem.getByTestId('media-image');
   await expect(image).toBeVisible({ timeout: 15000 });
 
-  if (hasProxy) {
-    const state = image.locator(
-      '[data-testid="media-image-loading"], [data-testid="media-image-element"], [data-testid="media-image-error"]',
-    );
-    await expect(state.first()).toBeVisible({ timeout: 15000 });
-    return;
-  }
-
-  const unavailable = image.getByTestId('media-image-unavailable');
-  await expect(unavailable).toBeVisible({ timeout: 15000 });
-  await expect(unavailable).toContainText('project diagram');
+  const state = image.locator(
+    '[data-testid="media-image-loading"], [data-testid="media-image-error"]',
+  );
+  await expect(state.first()).toBeVisible({ timeout: 15000 });
 });
 
 test('renders multiple inline images in a single message', async ({ page }) => {
@@ -149,14 +103,9 @@ test('renders multiple inline images in a single message', async ({ page }) => {
   const anchor = `Inline image gallery ${now}`;
   const message = `${anchor}: ![diagram one](https://httpbin.org/image/png) ![diagram two](https://httpbin.org/image/jpeg) ![diagram three](https://httpbin.org/image/svg)`;
 
-  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
+  const messageItem = await openChatWithMessage(page, message, anchor);
   await expect(messageItem.getByTestId('media-image')).toHaveCount(3);
-
-  if (hasProxy) {
-    await expect(messageItem.getByTestId('media-image-element')).toHaveCount(3, { timeout: 15000 });
-  } else {
-    await expect(messageItem.getByTestId('media-image-unavailable')).toHaveCount(3, { timeout: 15000 });
-  }
+  await expect(messageItem.getByTestId('media-image-element')).toHaveCount(3, { timeout: 15000 });
 });
 
 test('renders video when alt text is "video"', async ({ page }) => {
@@ -164,8 +113,8 @@ test('renders video when alt text is "video"', async ({ page }) => {
   const anchor = `Inline video ${now}`;
   const message = `${anchor}: Watch this: ![video](https://example.com/demo.mp4)`;
 
-  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
-  await expectInlineVideo(messageItem, hasProxy);
+  const messageItem = await openChatWithMessage(page, message, anchor);
+  await expectInlineVideo(messageItem);
 });
 
 test('renders audio when alt text is "audio"', async ({ page }) => {
@@ -173,8 +122,8 @@ test('renders audio when alt text is "audio"', async ({ page }) => {
   const anchor = `Inline audio ${now}`;
   const message = `${anchor}: Listen: ![audio](https://example.com/podcast.mp3)`;
 
-  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
-  await expectInlineAudio(messageItem, hasProxy);
+  const messageItem = await openChatWithMessage(page, message, anchor);
+  await expectInlineAudio(messageItem);
 });
 
 test('renders mixed media types in one message', async ({ page }) => {
@@ -182,13 +131,13 @@ test('renders mixed media types in one message', async ({ page }) => {
   const anchor = `Inline mixed media ${now}`;
   const message = `${anchor}: ![diagram](https://httpbin.org/image/png) ![video](https://example.com/demo.mp4) ![audio](https://example.com/podcast.mp3)`;
 
-  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
+  const messageItem = await openChatWithMessage(page, message, anchor);
   await expect(messageItem.getByTestId('media-image')).toHaveCount(1);
   await expect(messageItem.getByTestId('media-video')).toHaveCount(1);
   await expect(messageItem.getByTestId('media-audio')).toHaveCount(1);
-  await expectInlineImage(messageItem, 'diagram', hasProxy);
-  await expectInlineVideo(messageItem, hasProxy);
-  await expectInlineAudio(messageItem, hasProxy);
+  await expectInlineImage(messageItem, 'diagram');
+  await expectInlineVideo(messageItem);
+  await expectInlineAudio(messageItem);
   await argosScreenshot(page, 'inline-media-mixed');
 });
 
@@ -198,10 +147,10 @@ test('message with markdown text and inline image renders both', async ({ page }
   const anchor = heading;
   const message = `# ${heading}\n\nThis is **important**: ![release screenshot](https://httpbin.org/image/png)\n\nFinal notes.`;
 
-  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
+  const messageItem = await openChatWithMessage(page, message, anchor);
   await expect(messageItem.getByRole('heading', { name: heading })).toBeVisible({ timeout: 15000 });
   await expect(messageItem.locator('strong', { hasText: 'important' })).toBeVisible({ timeout: 15000 });
-  await expectInlineImage(messageItem, 'release screenshot', hasProxy);
+  await expectInlineImage(messageItem, 'release screenshot');
   await expect(messageItem).toContainText('Final notes.');
   await argosScreenshot(page, 'inline-media-markdown');
 });

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -111,7 +111,9 @@ test('renders multiple inline images in a single message', async ({ page }) => {
 
   const messageItem = await openChatWithMessage(page, message, anchor);
   await expect(messageItem.getByTestId('media-image')).toHaveCount(3);
-  await expect(messageItem.getByTestId('media-image-element')).toHaveCount(3, { timeout: 15000 });
+  for (const altText of ['diagram one', 'diagram two', 'diagram three']) {
+    await expectInlineImage(messageItem, altText);
+  }
 });
 
 test('renders video when alt text is "video"', async ({ page }) => {

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -51,7 +51,7 @@ async function expectInlineImage(
   messageItem: Locator,
   altText: string,
 ): Promise<void> {
-  const image = messageItem.getByTestId('media-image').filter({ hasText: altText });
+  const image = messageItem.locator(`[data-testid="media-image"][data-alt="${altText}"]`);
   await expect(image).toBeVisible({ timeout: 15000 });
 
   const resolved = image.locator(

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -1,0 +1,195 @@
+import { argosScreenshot } from '@argos-ci/playwright';
+import * as crypto from 'node:crypto';
+import type { Locator, Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import { createAgent, createChat, createOrganization, sendChatMessage } from './chat-api';
+import { setSelectedOrganization } from './organization-helpers';
+
+const AGENT_ROLE = 'assistant';
+const AGENT_DESCRIPTION = 'E2E inline media agent';
+const AGENT_CONFIGURATION = '{}';
+const AGENT_IMAGE = 'alpine:3.21';
+
+function buildAgentOptions(organizationId: string, name: string) {
+  return {
+    organizationId,
+    name,
+    role: AGENT_ROLE,
+    model: crypto.randomUUID(),
+    description: AGENT_DESCRIPTION,
+    configuration: AGENT_CONFIGURATION,
+    image: AGENT_IMAGE,
+  };
+}
+
+async function getMediaProxyUrl(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const config = (window as { __APP_CONFIG?: { MEDIA_PROXY_URL?: unknown } }).__APP_CONFIG;
+    const value = config?.MEDIA_PROXY_URL;
+    return typeof value === 'string' && value.trim() ? value.trim() : null;
+  });
+}
+
+async function openChatWithMessage(
+  page: Page,
+  message: string,
+  anchorText: string,
+): Promise<{ messageItem: Locator; hasProxy: boolean }> {
+  const now = Date.now();
+  const organizationId = await createOrganization(page, `e2e-org-inline-media-${now}`);
+  const agentId = await createAgent(page, buildAgentOptions(organizationId, `e2e-agent-inline-media-${now}`));
+  const chatId = await createChat(page, organizationId, agentId);
+  await sendChatMessage(page, chatId, message);
+  await setSelectedOrganization(page, organizationId);
+
+  const messagesLoaded = page.waitForResponse(
+    (resp) => resp.url().includes('GetMessages') && resp.status() === 200,
+    { timeout: 15000 },
+  );
+  await page.goto(`/chats/${encodeURIComponent(chatId)}`);
+  await messagesLoaded;
+
+  const messageItem = page.getByTestId('chat-message').filter({ hasText: anchorText });
+  await expect(messageItem).toBeVisible({ timeout: 15000 });
+
+  const hasProxy = Boolean(await getMediaProxyUrl(page));
+  return { messageItem, hasProxy };
+}
+
+async function expectInlineImage(
+  messageItem: Locator,
+  altText: string,
+  hasProxy: boolean,
+): Promise<void> {
+  const image = messageItem.getByTestId('media-image');
+  await expect(image).toBeVisible({ timeout: 15000 });
+
+  if (hasProxy) {
+    const resolved = image.locator(
+      '[data-testid="media-image-element"], [data-testid="media-image-error"]',
+    );
+    await expect(resolved.first()).toBeVisible({ timeout: 15000 });
+    const element = image.getByTestId('media-image-element');
+    if (await element.count()) {
+      await expect(element).toHaveAttribute('alt', altText);
+    } else {
+      await expect(image.getByTestId('media-image-error')).toContainText(altText);
+    }
+    return;
+  }
+
+  const unavailable = image.getByTestId('media-image-unavailable');
+  await expect(unavailable).toBeVisible({ timeout: 15000 });
+  await expect(unavailable).toContainText(altText);
+}
+
+async function expectInlineMediaFallback(
+  root: Locator,
+  elementTestId: string,
+  hasProxy: boolean,
+): Promise<void> {
+  const element = root.getByTestId(elementTestId);
+  const fallback = root.getByTestId('media-fallback');
+  const resolved = root.locator(
+    `[data-testid="${elementTestId}"], [data-testid="media-fallback"]`,
+  );
+  await expect(resolved.first()).toBeVisible({ timeout: 15000 });
+
+  if (!hasProxy) {
+    await expect(fallback).toBeVisible({ timeout: 15000 });
+    return;
+  }
+
+  if (await element.count()) {
+    await expect(element).toBeVisible({ timeout: 15000 });
+  } else {
+    await expect(fallback).toBeVisible({ timeout: 15000 });
+  }
+}
+
+async function expectInlineVideo(messageItem: Locator, hasProxy: boolean): Promise<void> {
+  const video = messageItem.getByTestId('media-video');
+  await expect(video).toBeVisible({ timeout: 15000 });
+  await expectInlineMediaFallback(video, 'media-video-element', hasProxy);
+}
+
+async function expectInlineAudio(messageItem: Locator, hasProxy: boolean): Promise<void> {
+  const audio = messageItem.getByTestId('media-audio');
+  await expect(audio).toBeVisible({ timeout: 15000 });
+  await expectInlineMediaFallback(audio, 'media-audio-element', hasProxy);
+}
+
+test('renders inline image from markdown with external URL', async ({ page }) => {
+  const now = Date.now();
+  const anchor = `Inline image external ${now}`;
+  const message = `${anchor}: Here is a photo: ![a sunset over the ocean](https://example.com/photo.png)`;
+
+  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
+  await expectInlineImage(messageItem, 'a sunset over the ocean', hasProxy);
+  await argosScreenshot(page, 'inline-media-image-external');
+});
+
+test('renders inline image with agyn:// protocol URL', async ({ page }) => {
+  const now = Date.now();
+  const anchor = `Inline image agyn ${now}`;
+  const message = `${anchor}: Attached image: ![project diagram](agyn://file/550e8400-e29b-41d4-a716-446655440000)`;
+
+  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
+  await expectInlineImage(messageItem, 'project diagram', hasProxy);
+});
+
+test('renders multiple inline images in a single message', async ({ page }) => {
+  const now = Date.now();
+  const anchor = `Inline image gallery ${now}`;
+  const message = `${anchor}: ![diagram one](https://example.com/one.png) ![diagram two](https://example.com/two.png) ![diagram three](https://example.com/three.png)`;
+
+  const { messageItem } = await openChatWithMessage(page, message, anchor);
+  await expect(messageItem.getByTestId('media-image')).toHaveCount(3);
+});
+
+test('renders video when alt text is "video"', async ({ page }) => {
+  const now = Date.now();
+  const anchor = `Inline video ${now}`;
+  const message = `${anchor}: Watch this: ![video](https://example.com/demo.mp4)`;
+
+  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
+  await expectInlineVideo(messageItem, hasProxy);
+});
+
+test('renders audio when alt text is "audio"', async ({ page }) => {
+  const now = Date.now();
+  const anchor = `Inline audio ${now}`;
+  const message = `${anchor}: Listen: ![audio](https://example.com/podcast.mp3)`;
+
+  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
+  await expectInlineAudio(messageItem, hasProxy);
+});
+
+test('renders mixed media types in one message', async ({ page }) => {
+  const now = Date.now();
+  const anchor = `Inline mixed media ${now}`;
+  const message = `${anchor}: ![diagram](https://example.com/diagram.png) ![video](https://example.com/demo.mp4) ![audio](https://example.com/podcast.mp3)`;
+
+  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
+  await expect(messageItem.getByTestId('media-image')).toHaveCount(1);
+  await expect(messageItem.getByTestId('media-video')).toHaveCount(1);
+  await expect(messageItem.getByTestId('media-audio')).toHaveCount(1);
+  await expectInlineImage(messageItem, 'diagram', hasProxy);
+  await expectInlineVideo(messageItem, hasProxy);
+  await expectInlineAudio(messageItem, hasProxy);
+  await argosScreenshot(page, 'inline-media-mixed');
+});
+
+test('message with markdown text and inline image renders both', async ({ page }) => {
+  const now = Date.now();
+  const heading = `Release update ${now}`;
+  const anchor = heading;
+  const message = `# ${heading}\n\nThis is **important**: ![release screenshot](https://example.com/release.png)\n\nFinal notes.`;
+
+  const { messageItem, hasProxy } = await openChatWithMessage(page, message, anchor);
+  await expect(messageItem.getByRole('heading', { name: heading })).toBeVisible({ timeout: 15000 });
+  await expect(messageItem.locator('strong', { hasText: 'important' })).toBeVisible({ timeout: 15000 });
+  await expectInlineImage(messageItem, 'release screenshot', hasProxy);
+  await expect(messageItem).toContainText('Final notes.');
+  await argosScreenshot(page, 'inline-media-markdown');
+});

--- a/test/e2e/organization-switching.spec.ts
+++ b/test/e2e/organization-switching.spec.ts
@@ -118,7 +118,7 @@ test('org switcher highlights current org', async ({ page }) => {
 
   await switchOrganization(page, orgAId);
   await openOrganizationMenu(page);
-  await expect(page.getByTestId('current-org-name')).toHaveText(orgAName);
+  await expect(page.getByTestId('current-org-name')).toHaveText(orgAName, { timeout: 15_000 });
   await expect(page.getByTestId(`org-item-${orgAId}`)).toHaveAttribute('data-state', 'checked');
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
     },
     {
       "path": "./tsconfig.node.json"
+    },
+    {
+      "path": "./tsconfig.sw.json"
     }
   ],
   "compilerOptions": {

--- a/tsconfig.sw.json
+++ b/tsconfig.sw.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "WebWorker"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": false,
+    "moduleDetection": "force",
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "types": []
+  },
+  "include": ["src/sw.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,67 @@
 import path from 'path';
+import { build } from 'esbuild';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import { configDefaults } from 'vitest/config';
 
 const gatewayTarget = process.env.VITE_GATEWAY_URL || 'http://gateway:8080';
 
+const swEntry = path.resolve(__dirname, 'src/sw.ts');
+const swTsconfig = path.resolve(__dirname, 'tsconfig.sw.json');
+const swOutfile = path.resolve(__dirname, 'dist/sw.js');
+const swDevOutfile = path.resolve(__dirname, 'public/sw.js');
+
+async function buildServiceWorker(outfile: string) {
+  await build({
+    entryPoints: [swEntry],
+    outfile,
+    bundle: true,
+    platform: 'browser',
+    format: 'iife',
+    target: ['es2022'],
+    tsconfig: swTsconfig,
+  });
+}
+
+function serviceWorkerBuildPlugin(): Plugin {
+  return {
+    name: 'service-worker-build',
+    apply: 'build',
+    async closeBundle() {
+      await buildServiceWorker(swOutfile);
+    },
+  };
+}
+
+function serviceWorkerDevPlugin(): Plugin {
+  return {
+    name: 'service-worker-dev',
+    apply: 'serve',
+    configureServer(server) {
+      const rebuild = () =>
+        buildServiceWorker(swDevOutfile).catch((error) => {
+          server.config.logger.error(`[service-worker] ${error instanceof Error ? error.message : error}`);
+        });
+
+      void rebuild();
+      server.watcher.add(swEntry);
+      server.watcher.on('change', (file) => {
+        if (path.resolve(file) === swEntry) {
+          void rebuild();
+        }
+      });
+    },
+  };
+}
+
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
+export default defineConfig(({ command }) => ({
+  plugins: [
+    react(),
+    tailwindcss(),
+    command === 'serve' ? serviceWorkerDevPlugin() : serviceWorkerBuildPlugin(),
+  ],
   test: {
     exclude: [...configDefaults.exclude, 'test/e2e/**'],
   },
@@ -31,4 +84,4 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
-});
+}));


### PR DESCRIPTION
## Summary
- add media proxy config, service worker registration/build, and proxy URL helpers
- render inline media + attachments with download fallbacks
- update markdown sanitization and nginx /sw.js handling
- add proxy URL unit tests

## Testing
- npm run lint
- npm run test
- npm run build

Relates to #56