### PR TITLE
Fix realtime chat updates via Notifications stream

### DIFF
--- a/src/api/hooks/chat-resources.ts
+++ b/src/api/hooks/chat-resources.ts
@@ -1,14 +1,12 @@
-import { useEffect, useMemo } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { chatResources } from '@/api/modules/chat-resources';
 import type { ChatActivity, ChatReminder } from '@/api/types/chat-resources';
-import { graphSocket } from '@/lib/graph/socket';
 import { UUID_REGEX } from '@/utils/validation';
 
 const DEFAULT_ACTIVITY: ChatActivity = 'idle';
 
 export function useChatActivity(chatId: string | undefined) {
-  const queryClient = useQueryClient();
   const queryKey = useMemo(() => ['chats', chatId, 'activity'] as const, [chatId]);
   const isValidChat = !!chatId && UUID_REGEX.test(chatId);
   const q = useQuery<ChatActivity>({
@@ -18,21 +16,6 @@ export function useChatActivity(chatId: string | undefined) {
     staleTime: 5000,
   });
 
-  useEffect(() => {
-    if (!chatId || !isValidChat) return;
-    const offActivity = graphSocket.onChatActivityChanged((payload) => {
-      if (payload.chatId !== chatId) return;
-      queryClient.setQueryData<ChatActivity>(queryKey, payload.activity);
-    });
-    const offReconnect = graphSocket.onReconnected(() => {
-      void queryClient.invalidateQueries({ queryKey });
-    });
-    return () => {
-      offActivity();
-      offReconnect();
-    };
-  }, [chatId, isValidChat, queryClient, queryKey]);
-
   return {
     ...q,
     data: q.data ?? DEFAULT_ACTIVITY,
@@ -40,7 +23,6 @@ export function useChatActivity(chatId: string | undefined) {
 }
 
 export function useChatReminders(chatId: string | undefined, enabled: boolean = true) {
-  const queryClient = useQueryClient();
   const queryKey = useMemo(() => ['chats', chatId, 'reminders'] as const, [chatId]);
   const isValidChat = !!chatId && UUID_REGEX.test(chatId);
   const q = useQuery<{ items: ChatReminder[] }>({
@@ -49,21 +31,6 @@ export function useChatReminders(chatId: string | undefined, enabled: boolean = 
     queryFn: () => chatResources.reminders(chatId as string),
     staleTime: 1500,
   });
-
-  useEffect(() => {
-    if (!chatId || !enabled || !isValidChat) return;
-    const offReminders = graphSocket.onChatRemindersCount((payload) => {
-      if (payload.chatId !== chatId) return;
-      void queryClient.invalidateQueries({ queryKey });
-    });
-    const offReconnect = graphSocket.onReconnected(() => {
-      void queryClient.invalidateQueries({ queryKey });
-    });
-    return () => {
-      offReminders();
-      offReconnect();
-    };
-  }, [chatId, enabled, isValidChat, queryClient, queryKey]);
 
   return q;
 }

--- a/src/api/hooks/chat.ts
+++ b/src/api/hooks/chat.ts
@@ -11,11 +11,8 @@ import type {
   SendMessageResponse,
   UpdateChatResponse,
 } from '@/api/types/chat';
-import { graphSocket } from '@/lib/graph/socket';
-
 const CHAT_PAGE_SIZE = 25;
 const MESSAGE_PAGE_SIZE = 30;
-const MESSAGE_POLL_INTERVAL_MS = 5000;
 
 export function useChats(organizationId: string | undefined) {
   return useInfiniteQuery({
@@ -35,11 +32,9 @@ export function useChats(organizationId: string | undefined) {
 }
 
 export function useChatMessages(chatId: string | null | undefined) {
-  const queryKey = ['chats', chatId ?? 'none', 'messages', MESSAGE_PAGE_SIZE] as const;
-
   return useInfiniteQuery({
     enabled: Boolean(chatId),
-    queryKey,
+    queryKey: ['chats', chatId ?? 'none', 'messages', MESSAGE_PAGE_SIZE],
     queryFn: ({ pageParam }) =>
       chatApi.getMessages({
         chatId: chatId as string,
@@ -50,8 +45,6 @@ export function useChatMessages(chatId: string | null | undefined) {
     getNextPageParam: (lastPage) => lastPage.nextPageToken ?? undefined,
     staleTime: 5000,
     refetchOnWindowFocus: false,
-    refetchInterval: () => (graphSocket.isConnected() ? false : MESSAGE_POLL_INTERVAL_MS),
-    refetchIntervalInBackground: true,
   });
 }
 

--- a/src/api/hooks/chat.ts
+++ b/src/api/hooks/chat.ts
@@ -11,9 +11,11 @@ import type {
   SendMessageResponse,
   UpdateChatResponse,
 } from '@/api/types/chat';
+import { graphSocket } from '@/lib/graph/socket';
 
 const CHAT_PAGE_SIZE = 25;
 const MESSAGE_PAGE_SIZE = 30;
+const MESSAGE_POLL_INTERVAL_MS = 5000;
 
 export function useChats(organizationId: string | undefined) {
   return useInfiniteQuery({
@@ -33,9 +35,11 @@ export function useChats(organizationId: string | undefined) {
 }
 
 export function useChatMessages(chatId: string | null | undefined) {
+  const queryKey = ['chats', chatId ?? 'none', 'messages', MESSAGE_PAGE_SIZE] as const;
+
   return useInfiniteQuery({
     enabled: Boolean(chatId),
-    queryKey: ['chats', chatId ?? 'none', 'messages', MESSAGE_PAGE_SIZE],
+    queryKey,
     queryFn: ({ pageParam }) =>
       chatApi.getMessages({
         chatId: chatId as string,
@@ -46,6 +50,8 @@ export function useChatMessages(chatId: string | null | undefined) {
     getNextPageParam: (lastPage) => lastPage.nextPageToken ?? undefined,
     staleTime: 5000,
     refetchOnWindowFocus: false,
+    refetchInterval: () => (graphSocket.isConnected() ? false : MESSAGE_POLL_INTERVAL_MS),
+    refetchIntervalInBackground: true,
   });
 }
 

--- a/src/api/notifications-connect.ts
+++ b/src/api/notifications-connect.ts
@@ -22,6 +22,12 @@ export type NotificationEnvelope = {
   payload: Record<string, unknown> | null;
 };
 
+export type MessageCreatedNotification = {
+  threadId: string;
+  messageId: string | null;
+  senderId: string | null;
+};
+
 function createEnvelope(payload: Uint8Array, flags = 0x00): Uint8Array {
   const envelope = new Uint8Array(5 + payload.length);
   envelope[0] = flags;
@@ -75,6 +81,19 @@ function parseNotificationEnvelope(value: unknown): NotificationEnvelope | null 
     : [];
   const payload = isRecord(envelope.payload) ? envelope.payload : null;
   return { event, rooms, payload };
+}
+
+export function parseMessageCreatedNotification(
+  envelope: NotificationEnvelope,
+): MessageCreatedNotification | null {
+  if (envelope.event !== 'message.created') return null;
+  const payload = envelope.payload;
+  if (!payload) return null;
+  const threadId = typeof payload.thread_id === 'string' ? payload.thread_id : null;
+  if (!threadId) return null;
+  const messageId = typeof payload.message_id === 'string' ? payload.message_id : null;
+  const senderId = typeof payload.sender_id === 'string' ? payload.sender_id : null;
+  return { threadId, messageId, senderId };
 }
 
 export async function* subscribeNotifications(

--- a/src/api/notifications-connect.ts
+++ b/src/api/notifications-connect.ts
@@ -1,0 +1,147 @@
+import { getAccessToken } from '@/auth';
+import { config } from '@/config';
+import { isRecord } from '@/api/parsing';
+
+const CONNECT_CONTENT_TYPE = 'application/connect+json';
+const CONNECT_PROTOCOL_VERSION = '1';
+const SUBSCRIBE_PATH = '/api/agynio.api.gateway.v1.NotificationsGateway/Subscribe';
+
+const textDecoder = new TextDecoder();
+const textEncoder = new TextEncoder();
+
+type EndStreamResponse = {
+  error?: {
+    code?: string;
+    message?: string;
+  };
+};
+
+export type NotificationEnvelope = {
+  event: string;
+  rooms: string[];
+  payload: Record<string, unknown> | null;
+};
+
+function createEnvelope(payload: Uint8Array, flags = 0x00): Uint8Array {
+  const envelope = new Uint8Array(5 + payload.length);
+  envelope[0] = flags;
+  const view = new DataView(envelope.buffer, envelope.byteOffset, envelope.byteLength);
+  view.setUint32(1, payload.length, false);
+  envelope.set(payload, 5);
+  return envelope;
+}
+
+function tryReadEnvelope(buffer: Uint8Array, offset: number) {
+  if (offset + 5 > buffer.length) return null;
+  const flags = buffer[offset];
+  const view = new DataView(buffer.buffer, buffer.byteOffset + offset + 1, 4);
+  const length = view.getUint32(0, false);
+  const start = offset + 5;
+  const end = start + length;
+  if (end > buffer.length) return null;
+  return { flags, data: buffer.subarray(start, end), nextOffset: end };
+}
+
+function concatBuffers(a: Uint8Array, b: Uint8Array): Uint8Array {
+  if (a.length === 0) return b;
+  const combined = new Uint8Array(a.length + b.length);
+  combined.set(a, 0);
+  combined.set(b, a.length);
+  return combined;
+}
+
+function parseEndStream(data: Uint8Array): void {
+  if (data.length === 0) return;
+  let payload: EndStreamResponse;
+  try {
+    payload = JSON.parse(textDecoder.decode(data)) as EndStreamResponse;
+  } catch (error) {
+    throw new Error('Failed to parse Connect end-stream response', { cause: error });
+  }
+  if (!payload.error) return;
+  const code = payload.error.code ?? 'unknown';
+  const message = payload.error.message ?? 'Notifications subscribe failed';
+  throw new Error(`Notifications subscribe failed (${code}): ${message}`);
+}
+
+function parseNotificationEnvelope(value: unknown): NotificationEnvelope | null {
+  if (!isRecord(value)) return null;
+  const envelope = value.envelope;
+  if (!isRecord(envelope)) return null;
+  const event = typeof envelope.event === 'string' ? envelope.event : null;
+  if (!event) return null;
+  const rooms = Array.isArray(envelope.rooms)
+    ? envelope.rooms.filter((room) => typeof room === 'string')
+    : [];
+  const payload = isRecord(envelope.payload) ? envelope.payload : null;
+  return { event, rooms, payload };
+}
+
+export async function* subscribeNotifications(
+  signal: AbortSignal,
+): AsyncGenerator<NotificationEnvelope> {
+  const token = await getAccessToken();
+  const headers = new Headers({
+    'Content-Type': CONNECT_CONTENT_TYPE,
+    'Connect-Protocol-Version': CONNECT_PROTOCOL_VERSION,
+    Accept: CONNECT_CONTENT_TYPE,
+  });
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const requestBody = createEnvelope(textEncoder.encode(JSON.stringify({})));
+  const response = await fetch(`${config.apiBaseUrl}${SUBSCRIBE_PATH}`, {
+    method: 'POST',
+    headers,
+    body: requestBody,
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => '');
+    const details = errorBody ? `: ${errorBody}` : '';
+    throw new Error(`Notifications subscribe failed with status ${response.status}${details}`);
+  }
+  if (!response.body) {
+    throw new Error('Notifications subscribe response body is empty');
+  }
+
+  const reader = response.body.getReader();
+  let buffer = new Uint8Array();
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (value) buffer = concatBuffers(buffer, value);
+
+    let offset = 0;
+    while (true) {
+      const envelope = tryReadEnvelope(buffer, offset);
+      if (!envelope) break;
+      offset = envelope.nextOffset;
+      if (envelope.flags === 0x02) {
+        parseEndStream(envelope.data);
+        return;
+      }
+      if (envelope.flags !== 0x00) {
+        throw new Error(`Unexpected response envelope flags: ${envelope.flags}`);
+      }
+
+      let payload: unknown;
+      try {
+        payload = JSON.parse(textDecoder.decode(envelope.data)) as unknown;
+      } catch (error) {
+        throw new Error('Failed to parse notifications response payload', { cause: error });
+      }
+      const parsed = parseNotificationEnvelope(payload);
+      if (parsed) {
+        yield parsed;
+      }
+    }
+
+    if (offset > 0) {
+      buffer = buffer.slice(offset);
+    }
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@
 type RuntimeConfig = {
   API_BASE_URL?: string;
   MEDIA_PROXY_URL?: string;
+  SOCKETS_ENABLED?: string;
   OIDC_AUTHORITY?: string;
   OIDC_CLIENT_ID?: string;
   OIDC_SCOPE?: string;
@@ -12,6 +13,7 @@ type RuntimeConfig = {
 type ViteEnv = {
   VITE_API_BASE_URL?: string;
   VITE_MEDIA_PROXY_URL?: string;
+  VITE_SOCKETS_ENABLED?: string;
   VITE_OIDC_AUTHORITY?: string;
   VITE_OIDC_CLIENT_ID?: string;
   VITE_OIDC_SCOPE?: string;
@@ -109,6 +111,11 @@ const mediaProxyUrl =
       ? deriveBase(rawMediaProxyUrl, { stripApi: false })
       : null;
 
+const rawSocketsEnabled = readConfigValue('SOCKETS_ENABLED', 'VITE_SOCKETS_ENABLED');
+const socketsEnabled = rawSocketsEnabled
+  ? !['false', '0', 'off'].includes(rawSocketsEnabled.trim().toLowerCase())
+  : true;
+
 const rawOidcAuthority = readConfigValue('OIDC_AUTHORITY', 'VITE_OIDC_AUTHORITY');
 const oidcEnabled = Boolean(rawOidcAuthority);
 
@@ -125,8 +132,13 @@ export const config = {
   apiBaseUrl,
   mediaProxyUrl,
   socketBaseUrl,
+  socketsEnabled,
 };
 
 export function getSocketBaseUrl(): string {
   return socketBaseUrl;
+}
+
+export function getSocketsEnabled(): boolean {
+  return socketsEnabled;
 }

--- a/src/hooks/useChatNotifications.ts
+++ b/src/hooks/useChatNotifications.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { graphSocket } from '@/lib/graph/socket';
+import { notificationsStream } from '@/lib/notifications/stream';
 
 type UseChatNotificationsOptions = {
   identityId: string | null | undefined;
@@ -20,35 +20,24 @@ export function useChatNotifications({
 
   useEffect(() => {
     if (!identityId) return;
-    const room = `thread_participant:${identityId}`;
-    graphSocket.subscribe([room]);
-
-    const offChatCreated = graphSocket.onChatCreated(() => {
-      void queryClient.invalidateQueries({ queryKey: ['chats', 'list'] });
-    });
-
-    const offChatUpdated = graphSocket.onChatUpdated(({ chat }) => {
-      void queryClient.invalidateQueries({ queryKey: ['chats', 'list'] });
-      if (selectedChatIdRef.current && selectedChatIdRef.current === chat.id) {
-        void queryClient.invalidateQueries({ queryKey: ['chats', chat.id, 'messages'] });
+    const offMessageCreated = notificationsStream.onEnvelope((envelope) => {
+      if (envelope.event !== 'message.created') return;
+      const payload = envelope.payload;
+      const threadId = payload && typeof payload.thread_id === 'string' ? payload.thread_id : null;
+      if (!threadId) return;
+      if (selectedChatIdRef.current && selectedChatIdRef.current === threadId) {
+        void queryClient.invalidateQueries({ queryKey: ['chats', threadId, 'messages'] });
       }
-    });
-
-    const offMessageCreated = graphSocket.onChatMessageCreated(({ chatId }) => {
-      void queryClient.invalidateQueries({ queryKey: ['chats', chatId, 'messages'] });
       void queryClient.invalidateQueries({ queryKey: ['chats', 'list'] });
     });
 
-    const offReconnect = graphSocket.onReconnected(() => {
+    const offReconnect = notificationsStream.onReconnect(() => {
       void queryClient.invalidateQueries({ queryKey: ['chats'] });
     });
 
     return () => {
-      offChatCreated();
-      offChatUpdated();
       offMessageCreated();
       offReconnect();
-      graphSocket.unsubscribe([room]);
     };
   }, [identityId, queryClient]);
 }

--- a/src/hooks/useChatNotifications.ts
+++ b/src/hooks/useChatNotifications.ts
@@ -20,11 +20,7 @@ export function useChatNotifications({
 
   useEffect(() => {
     if (!identityId) return;
-    const offMessageCreated = notificationsStream.onEnvelope((envelope) => {
-      if (envelope.event !== 'message.created') return;
-      const payload = envelope.payload;
-      const threadId = payload && typeof payload.thread_id === 'string' ? payload.thread_id : null;
-      if (!threadId) return;
+    const offMessageCreated = notificationsStream.onMessageCreated(({ threadId }) => {
       if (selectedChatIdRef.current && selectedChatIdRef.current === threadId) {
         void queryClient.invalidateQueries({ queryKey: ['chats', threadId, 'messages'] });
       }

--- a/src/hooks/useChatSoundNotifications.ts
+++ b/src/hooks/useChatSoundNotifications.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ChatListItem } from '@/components/ChatListItem';
-import { graphSocket } from '@/lib/graph/socket';
+import { notificationsStream } from '@/lib/notifications/stream';
 import { ChatSoundController } from '@/features/chats/ChatSoundController';
 
 type UseChatSoundNotificationsOptions = {
@@ -102,9 +102,12 @@ export function useChatSoundNotifications({
     const controller = controllerRef.current;
     if (!controller) return;
 
-    const unsubscribe = graphSocket.onChatMessageCreated(({ chatId, message }) => {
-      if (message.kind === 'user') return;
-      controller.handleMessageCreated(chatId);
+    const unsubscribe = notificationsStream.onEnvelope((envelope) => {
+      if (envelope.event !== 'message.created') return;
+      const payload = envelope.payload;
+      const threadId = payload && typeof payload.thread_id === 'string' ? payload.thread_id : null;
+      if (!threadId) return;
+      controller.handleMessageCreated(threadId);
     });
 
     return () => {

--- a/src/hooks/useChatSoundNotifications.ts
+++ b/src/hooks/useChatSoundNotifications.ts
@@ -102,11 +102,7 @@ export function useChatSoundNotifications({
     const controller = controllerRef.current;
     if (!controller) return;
 
-    const unsubscribe = notificationsStream.onEnvelope((envelope) => {
-      if (envelope.event !== 'message.created') return;
-      const payload = envelope.payload;
-      const threadId = payload && typeof payload.thread_id === 'string' ? payload.thread_id : null;
-      if (!threadId) return;
+    const unsubscribe = notificationsStream.onMessageCreated(({ threadId }) => {
       controller.handleMessageCreated(threadId);
     });
 

--- a/src/lib/graph/socket.ts
+++ b/src/lib/graph/socket.ts
@@ -1,7 +1,7 @@
 // CI trigger: no-op comment to touch UI file
 import { io, type ManagerOptions, type Socket, type SocketOptions } from 'socket.io-client';
 import { getAccessToken, userManager } from '@/auth';
-import { getSocketBaseUrl } from '@/config';
+import { getSocketBaseUrl, getSocketsEnabled } from '@/config';
 import type { NodeStatusEvent, ReminderCountEvent } from './types';
 
 // Strictly typed server-to-client socket events (listener signatures)
@@ -53,8 +53,7 @@ type ChatRemindersPayload = { chatId: string; remindersCount: number };
 type ChatMessageCreatedPayload = { message: MessageSummary; chatId: string };
 type ChatRunStatusChangedPayload = { chatId: string; run: ChatRunSummary };
 
-// TODO: restore production socket connections when backend is available.
-const socketsEnabled = !import.meta.env.PROD;
+const socketsEnabled = getSocketsEnabled();
 
 class GraphSocket {
   // Typed socket instance; null until connected
@@ -131,7 +130,10 @@ class GraphSocket {
     const handleDisconnect = () => {
       for (const fn of this.disconnectCallbacks) fn();
     };
-    const handleConnectError = () => {};
+    const handleConnectError = (error: Error) => {
+      const message = error?.message ?? String(error);
+      console.warn('[graphSocket] connect_error', message);
+    };
     socket.on('connect', handleConnect);
     this.socketCleanup.push(() => socket.off('connect', handleConnect));
     socket.on('disconnect', handleDisconnect);
@@ -260,6 +262,9 @@ class GraphSocket {
   subscribe(rooms: string[]) {
     const sock = this.connect();
     if (!sock) return;
+    if (socketsEnabled && !sock.connected) {
+      sock.connect();
+    }
     const toJoin: string[] = [];
     for (const room of rooms) {
       if (!room || this.subscribedRooms.has(room)) continue;

--- a/src/lib/graph/socket.ts
+++ b/src/lib/graph/socket.ts
@@ -261,7 +261,6 @@ class GraphSocket {
   // Subscribe to rooms
   subscribe(rooms: string[]) {
     const sock = this.connect();
-    if (!sock) return;
     if (socketsEnabled && !sock.connected) {
       sock.connect();
     }

--- a/src/lib/notifications/stream.ts
+++ b/src/lib/notifications/stream.ts
@@ -1,9 +1,15 @@
-import { subscribeNotifications, type NotificationEnvelope } from '@/api/notifications-connect';
+import {
+  parseMessageCreatedNotification,
+  subscribeNotifications,
+  type MessageCreatedNotification,
+  type NotificationEnvelope,
+} from '@/api/notifications-connect';
 
 const RECONNECT_DELAY_MS = 3000;
 
 type EnvelopeListener = (envelope: NotificationEnvelope) => void;
 type ReconnectListener = () => void;
+type MessageCreatedListener = (notification: MessageCreatedNotification) => void;
 
 class NotificationsStream {
   private abortController: AbortController | null = null;
@@ -18,6 +24,15 @@ class NotificationsStream {
       this.listeners.delete(cb);
       this.maybeDisconnect();
     };
+  }
+
+  onMessageCreated(cb: MessageCreatedListener): () => void {
+    const handler = (envelope: NotificationEnvelope) => {
+      const parsed = parseMessageCreatedNotification(envelope);
+      if (!parsed) return;
+      cb(parsed);
+    };
+    return this.onEnvelope(handler);
   }
 
   onReconnect(cb: ReconnectListener): () => void {

--- a/src/lib/notifications/stream.ts
+++ b/src/lib/notifications/stream.ts
@@ -1,0 +1,91 @@
+import { subscribeNotifications, type NotificationEnvelope } from '@/api/notifications-connect';
+
+const RECONNECT_DELAY_MS = 3000;
+
+type EnvelopeListener = (envelope: NotificationEnvelope) => void;
+type ReconnectListener = () => void;
+
+class NotificationsStream {
+  private abortController: AbortController | null = null;
+  private listeners = new Set<EnvelopeListener>();
+  private reconnectListeners = new Set<ReconnectListener>();
+  private hasConnected = false;
+
+  onEnvelope(cb: EnvelopeListener): () => void {
+    this.listeners.add(cb);
+    this.ensureConnected();
+    return () => {
+      this.listeners.delete(cb);
+      this.maybeDisconnect();
+    };
+  }
+
+  onReconnect(cb: ReconnectListener): () => void {
+    this.reconnectListeners.add(cb);
+    this.ensureConnected();
+    return () => {
+      this.reconnectListeners.delete(cb);
+      this.maybeDisconnect();
+    };
+  }
+
+  private ensureConnected() {
+    if (this.abortController) return;
+    this.abortController = new AbortController();
+    this.hasConnected = false;
+    void this.startStream();
+  }
+
+  private maybeDisconnect() {
+    if (this.listeners.size > 0 || this.reconnectListeners.size > 0) return;
+    this.disconnect();
+  }
+
+  private disconnect() {
+    this.abortController?.abort();
+    this.abortController = null;
+    this.hasConnected = false;
+  }
+
+  private emitEnvelope(envelope: NotificationEnvelope) {
+    for (const listener of this.listeners) {
+      listener(envelope);
+    }
+  }
+
+  private emitReconnect() {
+    for (const listener of this.reconnectListeners) {
+      listener();
+    }
+  }
+
+  private scheduleReconnect() {
+    if (this.listeners.size === 0 && this.reconnectListeners.size === 0) return;
+    globalThis.setTimeout(() => {
+      if (this.abortController?.signal.aborted) return;
+      void this.startStream();
+    }, RECONNECT_DELAY_MS);
+  }
+
+  private async startStream() {
+    const signal = this.abortController?.signal;
+    if (!signal) return;
+    const isReconnect = this.hasConnected;
+    this.hasConnected = true;
+    if (isReconnect) this.emitReconnect();
+
+    try {
+      for await (const envelope of subscribeNotifications(signal)) {
+        this.emitEnvelope(envelope);
+      }
+      if (signal.aborted) return;
+      this.scheduleReconnect();
+    } catch (error) {
+      if (signal.aborted) return;
+      console.warn('[notificationsStream] stream error', error);
+      this.scheduleReconnect();
+    }
+  }
+}
+
+export const notificationsStream = new NotificationsStream();

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_MEDIA_PROXY_URL?: string;
+  readonly VITE_SOCKETS_ENABLED?: string;
   readonly VITE_OIDC_AUTHORITY?: string;
   readonly VITE_OIDC_CLIENT_ID?: string;
   readonly VITE_OIDC_SCOPE?: string;
@@ -16,6 +17,7 @@ interface Window {
   __APP_CONFIG?: {
     API_BASE_URL?: string;
     MEDIA_PROXY_URL?: string;
+    SOCKETS_ENABLED?: string;
     OIDC_AUTHORITY?: string;
     OIDC_CLIENT_ID?: string;
     OIDC_SCOPE?: string;

--- a/test/e2e/chat-exchange.spec.ts
+++ b/test/e2e/chat-exchange.spec.ts
@@ -56,6 +56,10 @@ test('two users exchange messages in a shared chat', async ({ userAPage, userBPa
   const editorB = userBPage.getByTestId('markdown-composer-editor');
   await editorB.click();
   await userBPage.keyboard.type(messageFromB);
+  const userAMessagesRefetch = userAPage.waitForResponse(
+    (resp) => resp.url().includes('GetMessages') && resp.status() === 200,
+    { timeout: 15000 },
+  );
   const userBSendMessage = userBPage.waitForResponse(
     (resp) => resp.url().includes('SendMessage') && resp.status() === 200,
     { timeout: 15000 },
@@ -65,13 +69,7 @@ test('two users exchange messages in a shared chat', async ({ userAPage, userBPa
   await expect(userBPage.getByTestId('chat-message').filter({ hasText: messageFromB })).toBeVisible({
     timeout: 15000,
   });
-
-  const userAReloadedMessages = userAPage.waitForResponse(
-    (resp) => resp.url().includes('GetMessages') && resp.status() === 200,
-    { timeout: 15000 },
-  );
-  await userAPage.reload();
-  await userAReloadedMessages;
+  await userAMessagesRefetch;
   await expect(userAPage.getByTestId('chat-message').filter({ hasText: messageFromB })).toBeVisible({
     timeout: 15000,
   });

--- a/test/e2e/chat-exchange.spec.ts
+++ b/test/e2e/chat-exchange.spec.ts
@@ -56,10 +56,6 @@ test('two users exchange messages in a shared chat', async ({ userAPage, userBPa
   const editorB = userBPage.getByTestId('markdown-composer-editor');
   await editorB.click();
   await userBPage.keyboard.type(messageFromB);
-  const userAMessagesRefetch = userAPage.waitForResponse(
-    (resp) => resp.url().includes('GetMessages') && resp.status() === 200,
-    { timeout: 15000 },
-  );
   const userBSendMessage = userBPage.waitForResponse(
     (resp) => resp.url().includes('SendMessage') && resp.status() === 200,
     { timeout: 15000 },
@@ -69,7 +65,6 @@ test('two users exchange messages in a shared chat', async ({ userAPage, userBPa
   await expect(userBPage.getByTestId('chat-message').filter({ hasText: messageFromB })).toBeVisible({
     timeout: 15000,
   });
-  await userAMessagesRefetch;
   await expect(userAPage.getByTestId('chat-message').filter({ hasText: messageFromB })).toBeVisible({
     timeout: 15000,
   });

--- a/test/e2e/sign-in-helper.ts
+++ b/test/e2e/sign-in-helper.ts
@@ -53,7 +53,14 @@ export async function signInViaMockAuth(
   }
 
   if (!initialRoute || (initialRoute === 'app' && forceLogin)) {
-    await page.waitForURL(loginUrlPattern, { timeout: 15000 });
+    const loginReached = await page
+      .waitForURL(loginUrlPattern, { timeout: 15000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!loginReached) {
+      await expect(appReady).toBeVisible({ timeout: 30000 });
+      return false;
+    }
   }
 
   if (options.onLoginPage) {


### PR DESCRIPTION
## Summary
- implement realtime updates using `NotificationsGateway.Subscribe` (server-streaming ConnectRPC / gRPC-web)
- on `message.created` notifications, invalidate/refetch chat messages so new messages appear without a reload
- remove polling fallback + stop relying on `/socket.io`
- update Playwright E2E to assert realtime delivery without `page.reload()`

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- E2E_BASE_URL=http://localhost:3000 pnpm test:e2e

Fixes #60