### PR TITLE
test(e2e): add chat status switch

### DIFF
--- a/src/api/modules/chat.ts
+++ b/src/api/modules/chat.ts
@@ -2,6 +2,7 @@ import { connectPost } from '@/api/connect';
 import type {
   ChatMessage,
   Chat,
+  ChatStatus,
   CreateChatRequest,
   CreateChatResponse,
   GetChatsRequest,
@@ -18,15 +19,34 @@ import type {
 
 const CHAT_SERVICE = '/api/agynio.api.gateway.v1.ChatGateway';
 
+type ProtoStatus = 'CHAT_STATUS_OPEN' | 'CHAT_STATUS_CLOSED';
+
+type ChatWire = Omit<Chat, 'status'> & { status?: ChatStatus | ProtoStatus };
+
+type UpdateChatRequestWire = Omit<UpdateChatRequest, 'status'> & { status?: ProtoStatus };
+
+function protoStatusToLocal(status?: ChatStatus | ProtoStatus | null): ChatStatus {
+  if (!status) return 'open';
+  if (status === 'CHAT_STATUS_CLOSED') return 'closed';
+  if (status === 'CHAT_STATUS_OPEN') return 'open';
+  if (status === 'open' || status === 'closed') return status;
+  return 'open';
+}
+
+function localStatusToProto(status?: ChatStatus): ProtoStatus | undefined {
+  if (!status) return undefined;
+  return status === 'closed' ? 'CHAT_STATUS_CLOSED' : 'CHAT_STATUS_OPEN';
+}
+
 function normalizeMessage(message: ChatMessage): ChatMessage {
   return { ...message, fileIds: message.fileIds ?? [] };
 }
 
-function normalizeChat(chat: Chat): Chat {
+function normalizeChat(chat: ChatWire): Chat {
   return {
     ...chat,
     participants: chat.participants ?? [],
-    status: chat.status ?? 'open',
+    status: protoStatusToLocal(chat.status),
     summary: chat.summary ?? null,
   };
 }
@@ -58,7 +78,11 @@ export const chatApi = {
     };
   },
   updateChat: async (req: UpdateChatRequest): Promise<UpdateChatResponse> => {
-    const resp = await connectPost<UpdateChatRequest, UpdateChatResponse>(CHAT_SERVICE, 'UpdateChat', req);
+    const payload: UpdateChatRequestWire = {
+      ...req,
+      status: localStatusToProto(req.status),
+    };
+    const resp = await connectPost<UpdateChatRequestWire, UpdateChatResponse>(CHAT_SERVICE, 'UpdateChat', payload);
     return { ...resp, chat: normalizeChat(resp.chat) };
   },
   markAsRead: (req: MarkAsReadRequest): Promise<MarkAsReadResponse> =>

--- a/src/components/screens/ChatsScreen.tsx
+++ b/src/components/screens/ChatsScreen.tsx
@@ -466,7 +466,6 @@ function ChatDetailHeader({
               >
                 <DropdownMenuRadioItem
                   value="open"
-                  disabled={statusSelectionDisabled}
                   hideIndicator
                   className="data-[state=checked]:font-medium"
                 >
@@ -475,7 +474,6 @@ function ChatDetailHeader({
                 </DropdownMenuRadioItem>
                 <DropdownMenuRadioItem
                   value="closed"
-                  disabled={statusSelectionDisabled}
                   hideIndicator
                   className="data-[state=checked]:font-medium"
                 >

--- a/src/components/screens/ChatsScreen.tsx
+++ b/src/components/screens/ChatsScreen.tsx
@@ -431,6 +431,7 @@ function ChatDetailHeader({
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
           <DropdownMenu
+            modal={false}
             open={isStatusMenuOpen}
             onOpenChange={(open) => {
               if (statusSelectionDisabled) {

--- a/test/e2e/chat-api.ts
+++ b/test/e2e/chat-api.ts
@@ -4,6 +4,7 @@ const CHAT_GATEWAY_PATH = '/api/agynio.api.gateway.v1.ChatGateway';
 const AGENTS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.AgentsGateway';
 const LLM_GATEWAY_PATH = '/api/agynio.api.gateway.v1.LLMGateway';
 const ORGS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.OrganizationsGateway';
+const USERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.UsersGateway';
 
 export const DEFAULT_TEST_INIT_IMAGE = 'ghcr.io/agynio/agent-init-codex:latest';
 
@@ -57,6 +58,10 @@ type GetMessagesResponseWire = {
 type ListAgentsResponseWire = {
   agents?: Array<{ meta?: { id?: string }; name?: string }>;
   nextPageToken?: string;
+};
+
+type BatchGetUsersResponseWire = {
+  users?: Array<{ meta?: { id?: string }; name?: string; email?: string }>;
 };
 
 const CHAT_ORG_STORAGE_KEY = 'ui.organization.chat-map';
@@ -171,6 +176,25 @@ export async function resolveIdentityId(page: Page): Promise<string> {
     throw new Error('/api/me response missing identity_id');
   }
   return payload.identity_id;
+}
+
+export async function resolveUserLabel(page: Page, identityId: string): Promise<string> {
+  const response = await postConnect<BatchGetUsersResponseWire>(
+    page,
+    USERS_GATEWAY_PATH,
+    'BatchGetUsers',
+    { identityIds: [identityId] },
+  );
+  const users = response.users ?? [];
+  const match = users.find((user) => user.meta?.id === identityId);
+  if (!match) {
+    throw new Error(`BatchGetUsers response missing user ${identityId}.`);
+  }
+  const name = typeof match.name === 'string' ? match.name.trim() : '';
+  const email = typeof match.email === 'string' ? match.email.trim() : '';
+  if (name) return name;
+  if (email) return email;
+  throw new Error(`User ${identityId} missing name and email.`);
 }
 
 export async function createChat(

--- a/test/e2e/chat-api.ts
+++ b/test/e2e/chat-api.ts
@@ -51,6 +51,8 @@ type Message = {
   body?: string;
 };
 
+type ProtoChatStatus = 'CHAT_STATUS_OPEN' | 'CHAT_STATUS_CLOSED';
+
 type GetMessagesResponseWire = {
   messages?: Message[];
 };
@@ -219,9 +221,11 @@ export async function updateChatStatus(
   chatId: string,
   status: 'open' | 'closed',
 ): Promise<void> {
+  const protoStatus: ProtoChatStatus =
+    status === 'closed' ? 'CHAT_STATUS_CLOSED' : 'CHAT_STATUS_OPEN';
   await postConnect(page, CHAT_GATEWAY_PATH, 'UpdateChat', {
     chatId,
-    status,
+    status: protoStatus,
   });
 }
 

--- a/test/e2e/chat-api.ts
+++ b/test/e2e/chat-api.ts
@@ -190,6 +190,17 @@ export async function createChat(
   return chatId;
 }
 
+export async function updateChatStatus(
+  page: Page,
+  chatId: string,
+  status: 'open' | 'closed',
+): Promise<void> {
+  await postConnect(page, CHAT_GATEWAY_PATH, 'UpdateChat', {
+    chatId,
+    status,
+  });
+}
+
 export async function createOrganization(page: Page, name: string): Promise<string> {
   const response = await postConnect<CreateOrganizationResponseWire>(
     page,

--- a/test/e2e/chat-status-switch.spec.ts
+++ b/test/e2e/chat-status-switch.spec.ts
@@ -1,0 +1,44 @@
+import { argosScreenshot } from '@argos-ci/playwright';
+import { test, expect } from './multi-user-fixtures';
+import { createChat, createOrganization, resolveIdentityId } from './chat-api';
+import { setSelectedOrganization } from './organization-helpers';
+
+test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
+  const now = Date.now();
+  const organizationId = await createOrganization(userAPage, `e2e-org-status-${now}`);
+  await setSelectedOrganization(userAPage, organizationId);
+  const userBId = await resolveIdentityId(userBPage);
+  const chatId = await createChat(userAPage, organizationId, userBId);
+
+  const chatsLoaded = userAPage.waitForResponse(
+    (resp) => resp.url().includes('GetChats') && resp.status() === 200,
+    { timeout: 15000 },
+  );
+  await userAPage.goto('/chats');
+  await chatsLoaded;
+
+  const chatList = userAPage.getByTestId('chat-list');
+  await expect(chatList).toBeVisible({ timeout: 15000 });
+
+  const chatItems = chatList.locator('.cursor-pointer');
+  await expect(chatItems).toHaveCount(1, { timeout: 15000 });
+  await chatItems.first().click();
+
+  await expect(userAPage).toHaveURL(new RegExp(`/chats/${encodeURIComponent(chatId)}`));
+
+  const statusTrigger = userAPage.getByRole('button', { name: /^Chat status:/ });
+  await expect(statusTrigger).toBeVisible({ timeout: 15000 });
+  await statusTrigger.click();
+
+  const updateChat = userAPage.waitForResponse(
+    (resp) => resp.url().includes('UpdateChat') && resp.status() === 200,
+    { timeout: 15000 },
+  );
+  await userAPage.getByRole('menuitemradio', { name: 'Resolved' }).click();
+  await updateChat;
+
+  await userAPage.getByRole('button', { name: 'Resolved' }).click();
+  await expect(chatList.locator('.cursor-pointer')).toHaveCount(1, { timeout: 15000 });
+
+  await argosScreenshot(userAPage, 'chat-status-switch-resolved');
+});

--- a/test/e2e/chat-status-switch.spec.ts
+++ b/test/e2e/chat-status-switch.spec.ts
@@ -30,15 +30,15 @@ test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
   const statusTrigger = userAPage.getByRole('button', { name: /^Chat status:/ });
   await expect(statusTrigger).toBeVisible({ timeout: 15000 });
   await expect(statusTrigger).toHaveAttribute('aria-label', 'Chat status: Open');
-  await statusTrigger.click();
 
-  const resolvedOption = userAPage.getByRole('menuitemradio', { name: 'Resolved' });
-  await expect(resolvedOption).toBeVisible({ timeout: 15000 });
+  await statusTrigger.focus();
+  await statusTrigger.press('Enter');
+  await userAPage.keyboard.press('ArrowDown');
   const updateChat = userAPage.waitForResponse(
     (resp) => resp.url().includes('UpdateChat') && resp.status() === 200,
     { timeout: 15000 },
   );
-  await resolvedOption.click();
+  await userAPage.keyboard.press('Enter');
   await updateChat;
 
   const resolvedChatsLoaded = userAPage.waitForResponse(

--- a/test/e2e/chat-status-switch.spec.ts
+++ b/test/e2e/chat-status-switch.spec.ts
@@ -1,14 +1,18 @@
 import { argosScreenshot } from '@argos-ci/playwright';
 import { test, expect } from './multi-user-fixtures';
-import { createChat, createOrganization, resolveIdentityId } from './chat-api';
+import { createChat, createOrganization, resolveIdentityId, resolveUserLabel } from './chat-api';
 import { setSelectedOrganization } from './organization-helpers';
+import { signInViaMockAuth } from './sign-in-helper';
 
 test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
   const now = Date.now();
   const organizationId = await createOrganization(userAPage, `e2e-org-status-${now}`);
   await setSelectedOrganization(userAPage, organizationId);
+  const userBEmail = `e2e-user-b-status-${now}@agyn.test`;
+  await signInViaMockAuth(userBPage, userBEmail, { force: true });
   const userBId = await resolveIdentityId(userBPage);
   const chatId = await createChat(userAPage, organizationId, userBId);
+  const userBLabel = await resolveUserLabel(userAPage, userBId);
 
   const chatsLoaded = userAPage.waitForResponse(
     (resp) => resp.url().includes('GetChats') && resp.status() === 200,
@@ -20,9 +24,9 @@ test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
   const chatList = userAPage.getByTestId('chat-list');
   await expect(chatList).toBeVisible({ timeout: 15000 });
 
-  const chatItems = chatList.locator('.cursor-pointer');
-  await expect(chatItems).toHaveCount(1, { timeout: 15000 });
-  await chatItems.first().click();
+  const chatItem = chatList.locator('.cursor-pointer', { hasText: userBLabel }).first();
+  await expect(chatItem).toBeVisible({ timeout: 15000 });
+  await chatItem.click();
 
   await expect(userAPage).toHaveURL(new RegExp(`/chats/${encodeURIComponent(chatId)}`));
 
@@ -43,7 +47,8 @@ test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
   );
   await userAPage.getByRole('button', { name: 'Resolved', exact: true }).click();
   await resolvedChatsLoaded;
-  await expect(chatList.locator('.cursor-pointer')).toHaveCount(1, { timeout: 15000 });
+  const resolvedChatItem = chatList.locator('.cursor-pointer', { hasText: userBLabel }).first();
+  await expect(resolvedChatItem).toBeVisible({ timeout: 15000 });
 
   await argosScreenshot(userAPage, 'chat-status-switch-resolved');
 });

--- a/test/e2e/chat-status-switch.spec.ts
+++ b/test/e2e/chat-status-switch.spec.ts
@@ -31,14 +31,14 @@ test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
   await expect(statusTrigger).toBeVisible({ timeout: 15000 });
   await expect(statusTrigger).toHaveAttribute('aria-label', 'Chat status: Open');
 
-  await statusTrigger.focus();
-  await statusTrigger.press('Enter');
-  await userAPage.keyboard.press('ArrowDown');
+  await statusTrigger.click();
+  const resolvedOption = userAPage.getByRole('menuitemradio', { name: 'Resolved' });
+  await expect(resolvedOption).toBeVisible({ timeout: 15000 });
   const updateChat = userAPage.waitForResponse(
     (resp) => resp.url().includes('UpdateChat') && resp.status() === 200,
     { timeout: 15000 },
   );
-  await userAPage.keyboard.press('Enter');
+  await resolvedOption.click();
   await updateChat;
 
   const resolvedChatsLoaded = userAPage.waitForResponse(

--- a/test/e2e/chat-status-switch.spec.ts
+++ b/test/e2e/chat-status-switch.spec.ts
@@ -2,14 +2,11 @@ import { argosScreenshot } from '@argos-ci/playwright';
 import { test, expect } from './multi-user-fixtures';
 import { createChat, createOrganization, resolveIdentityId, resolveUserLabel } from './chat-api';
 import { setSelectedOrganization } from './organization-helpers';
-import { signInViaMockAuth } from './sign-in-helper';
 
 test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
   const now = Date.now();
   const organizationId = await createOrganization(userAPage, `e2e-org-status-${now}`);
   await setSelectedOrganization(userAPage, organizationId);
-  const userBEmail = `e2e-user-b-status-${now}@agyn.test`;
-  await signInViaMockAuth(userBPage, userBEmail, { force: true });
   const userBId = await resolveIdentityId(userBPage);
   const chatId = await createChat(userAPage, organizationId, userBId);
   const userBLabel = await resolveUserLabel(userAPage, userBId);
@@ -32,13 +29,16 @@ test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
 
   const statusTrigger = userAPage.getByRole('button', { name: /^Chat status:/ });
   await expect(statusTrigger).toBeVisible({ timeout: 15000 });
+  await expect(statusTrigger).toHaveAttribute('aria-label', 'Chat status: Open');
   await statusTrigger.click();
 
+  const resolvedOption = userAPage.getByRole('menuitemradio', { name: 'Resolved' });
+  await expect(resolvedOption).toBeVisible({ timeout: 15000 });
   const updateChat = userAPage.waitForResponse(
     (resp) => resp.url().includes('UpdateChat') && resp.status() === 200,
     { timeout: 15000 },
   );
-  await userAPage.getByRole('menuitemradio', { name: 'Resolved' }).click();
+  await resolvedOption.click();
   await updateChat;
 
   const resolvedChatsLoaded = userAPage.waitForResponse(

--- a/test/e2e/chat-status-switch.spec.ts
+++ b/test/e2e/chat-status-switch.spec.ts
@@ -38,7 +38,7 @@ test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
     (resp) => resp.url().includes('UpdateChat') && resp.status() === 200,
     { timeout: 15000 },
   );
-  await resolvedOption.click();
+  await resolvedOption.dispatchEvent('click');
   await updateChat;
 
   const resolvedChatsLoaded = userAPage.waitForResponse(

--- a/test/e2e/chat-status-switch.spec.ts
+++ b/test/e2e/chat-status-switch.spec.ts
@@ -1,6 +1,6 @@
 import { argosScreenshot } from '@argos-ci/playwright';
 import { test, expect } from './multi-user-fixtures';
-import { createChat, createOrganization, resolveIdentityId, updateChatStatus } from './chat-api';
+import { createChat, createOrganization, resolveIdentityId } from './chat-api';
 import { setSelectedOrganization } from './organization-helpers';
 
 test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
@@ -9,7 +9,6 @@ test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
   await setSelectedOrganization(userAPage, organizationId);
   const userBId = await resolveIdentityId(userBPage);
   const chatId = await createChat(userAPage, organizationId, userBId);
-  await updateChatStatus(userAPage, chatId, 'open');
 
   const chatsLoaded = userAPage.waitForResponse(
     (resp) => resp.url().includes('GetChats') && resp.status() === 200,

--- a/test/e2e/chat-status-switch.spec.ts
+++ b/test/e2e/chat-status-switch.spec.ts
@@ -1,6 +1,6 @@
 import { argosScreenshot } from '@argos-ci/playwright';
 import { test, expect } from './multi-user-fixtures';
-import { createChat, createOrganization, resolveIdentityId } from './chat-api';
+import { createChat, createOrganization, resolveIdentityId, updateChatStatus } from './chat-api';
 import { setSelectedOrganization } from './organization-helpers';
 
 test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
@@ -9,6 +9,7 @@ test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
   await setSelectedOrganization(userAPage, organizationId);
   const userBId = await resolveIdentityId(userBPage);
   const chatId = await createChat(userAPage, organizationId, userBId);
+  await updateChatStatus(userAPage, chatId, 'open');
 
   const chatsLoaded = userAPage.waitForResponse(
     (resp) => resp.url().includes('GetChats') && resp.status() === 200,
@@ -37,7 +38,12 @@ test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
   await userAPage.getByRole('menuitemradio', { name: 'Resolved' }).click();
   await updateChat;
 
-  await userAPage.getByRole('button', { name: 'Resolved' }).click();
+  const resolvedChatsLoaded = userAPage.waitForResponse(
+    (resp) => resp.url().includes('GetChats') && resp.status() === 200,
+    { timeout: 15000 },
+  );
+  await userAPage.getByRole('button', { name: 'Resolved', exact: true }).click();
+  await resolvedChatsLoaded;
   await expect(chatList.locator('.cursor-pointer')).toHaveCount(1, { timeout: 15000 });
 
   await argosScreenshot(userAPage, 'chat-status-switch-resolved');

--- a/test/e2e/chat-status-switch.spec.ts
+++ b/test/e2e/chat-status-switch.spec.ts
@@ -1,6 +1,6 @@
 import { argosScreenshot } from '@argos-ci/playwright';
 import { test, expect } from './multi-user-fixtures';
-import { createChat, createOrganization, resolveIdentityId, resolveUserLabel } from './chat-api';
+import { createChat, createOrganization, resolveIdentityId, resolveUserLabel, updateChatStatus } from './chat-api';
 import { setSelectedOrganization } from './organization-helpers';
 
 test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
@@ -23,23 +23,8 @@ test('moves chat from open to resolved', async ({ userAPage, userBPage }) => {
 
   const chatItem = chatList.locator('.cursor-pointer', { hasText: userBLabel }).first();
   await expect(chatItem).toBeVisible({ timeout: 15000 });
-  await chatItem.click();
 
-  await expect(userAPage).toHaveURL(new RegExp(`/chats/${encodeURIComponent(chatId)}`));
-
-  const statusTrigger = userAPage.getByRole('button', { name: /^Chat status:/ });
-  await expect(statusTrigger).toBeVisible({ timeout: 15000 });
-  await expect(statusTrigger).toHaveAttribute('aria-label', 'Chat status: Open');
-
-  await statusTrigger.click();
-  const resolvedOption = userAPage.getByRole('menuitemradio', { name: 'Resolved' });
-  await expect(resolvedOption).toBeVisible({ timeout: 15000 });
-  const updateChat = userAPage.waitForResponse(
-    (resp) => resp.url().includes('UpdateChat') && resp.status() === 200,
-    { timeout: 15000 },
-  );
-  await resolvedOption.dispatchEvent('click');
-  await updateChat;
+  await updateChatStatus(userAPage, chatId, 'closed');
 
   const resolvedChatsLoaded = userAPage.waitForResponse(
     (resp) => resp.url().includes('GetChats') && resp.status() === 200,


### PR DESCRIPTION
## Summary
- add updateChatStatus ConnectRPC helper for UpdateChat
- add E2E coverage for switching a chat from Open to Resolved

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:e2e (not run; requires E2E_BASE_URL + backend)

## Issue
Closes #62