### PR TITLE
feat(chats): add user menu header

### DIFF
--- a/src/components/screens/ChatsScreen.tsx
+++ b/src/components/screens/ChatsScreen.tsx
@@ -84,7 +84,7 @@ function AppLogo() {
   );
 }
 
-function UserMenu() {
+export function UserMenu() {
   const { user } = useUser();
   const { organizations, selectedOrganizationId, selectOrganization } = useOrganization();
   const userInitials = useMemo(() => getInitials(user?.name ?? user?.email), [user?.name, user?.email]);

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -5,7 +5,7 @@ import type { ChatListItem } from '@/components/ChatListItem';
 import type { ChatMessage, ChatQueuedMessageData, ChatReminderData, ChatRun } from '@/components/Chat';
 import { MarkdownContent } from '@/components/MarkdownContent';
 import { MessageAttachments } from '@/components/MessageAttachments';
-import ChatsScreen from '@/components/screens/ChatsScreen';
+import ChatsScreen, { UserMenu } from '@/components/screens/ChatsScreen';
 import { notifyError } from '@/lib/notify';
 import { useUser } from '@/user/user.runtime';
 import { useOrganization } from '@/organization/organization.runtime';
@@ -63,16 +63,21 @@ const resolveChatSummary = (summary: string | null | undefined): string | undefi
 
 function NoOrganizationsScreen() {
   return (
-    <div
-      className="flex h-full min-h-0 flex-1 items-center justify-center bg-[var(--agyn-bg-light)] p-6 text-center"
-      data-testid="no-organizations-screen"
-    >
-      <div className="max-w-md space-y-3">
-        <h2 className="text-lg font-semibold text-[var(--agyn-dark)]">Join or create an organization</h2>
-        <p className="text-sm text-[var(--agyn-gray)]">
-          You do not have access to any organizations yet. Ask for an invite from a teammate or create a new
-          organization to start chatting.
-        </p>
+    <div className="flex h-full min-h-0 flex-1 flex-col bg-[var(--agyn-bg-light)]">
+      <div className="flex items-center justify-end px-4 py-3">
+        <UserMenu />
+      </div>
+      <div
+        className="flex flex-1 items-center justify-center p-6 text-center"
+        data-testid="no-organizations-screen"
+      >
+        <div className="max-w-md space-y-3">
+          <h2 className="text-lg font-semibold text-[var(--agyn-dark)]">Join or create an organization</h2>
+          <p className="text-sm text-[var(--agyn-gray)]">
+            You do not have access to any organizations yet. Ask for an invite from a teammate or create a new
+            organization to start chatting.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/test/e2e/organization-switching.spec.ts
+++ b/test/e2e/organization-switching.spec.ts
@@ -172,4 +172,6 @@ base('no-organizations screen', async ({ page }) => {
     await signInViaMockAuth(page, uniqueEmail, { force: true });
   }
   await baseExpect(page.getByTestId('no-organizations-screen')).toBeVisible({ timeout: 15000 });
+  await baseExpect(page.getByTestId('user-menu-trigger')).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'no-organizations-screen');
 });


### PR DESCRIPTION
## Summary
- export the chats UserMenu for reuse
- add a header with the user menu on the no-organizations screen

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Fixes #66