### PR TITLE
feat(chat): handle degraded threads

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -111,10 +111,10 @@ pipelines:
         -- bash -c '
           echo "Waiting for file sync..."
           for i in $(seq 1 60); do
-            [ -f /opt/app/data/package.json ] && [ -f /opt/app/data/pnpm-lock.yaml ] && [ -f /opt/app/data/test/e2e/fixtures.ts ] && [ -f /opt/app/data/test/e2e/multi-user-fixtures.ts ] && [ -f /opt/app/data/test/e2e/chat-api.ts ] && [ -f /opt/app/data/test/e2e/chat-exchange.spec.ts ] && [ -f /opt/app/data/test/e2e/chat-detail.spec.ts ] && [ -f /opt/app/data/test/e2e/chats-list.spec.ts ] && [ -f /opt/app/data/test/e2e/sign-in-helper.ts ] && [ -f /opt/app/data/test/e2e/sign-in.spec.ts ] && break
+            [ -f /opt/app/data/package.json ] && [ -f /opt/app/data/pnpm-lock.yaml ] && [ -f /opt/app/data/test/e2e/fixtures.ts ] && [ -f /opt/app/data/test/e2e/multi-user-fixtures.ts ] && [ -f /opt/app/data/test/e2e/chat-api.ts ] && [ -f /opt/app/data/test/e2e/chat-exchange.spec.ts ] && [ -f /opt/app/data/test/e2e/chat-detail.spec.ts ] && [ -f /opt/app/data/test/e2e/chats-list.spec.ts ] && [ -f /opt/app/data/test/e2e/file-upload.spec.ts ] && [ -f /opt/app/data/test/e2e/sign-in-helper.ts ] && [ -f /opt/app/data/test/e2e/sign-in.spec.ts ] && break
             sleep 2
           done
-          if [ ! -f /opt/app/data/package.json ] || [ ! -f /opt/app/data/pnpm-lock.yaml ] || [ ! -f /opt/app/data/test/e2e/fixtures.ts ] || [ ! -f /opt/app/data/test/e2e/multi-user-fixtures.ts ] || [ ! -f /opt/app/data/test/e2e/chat-api.ts ] || [ ! -f /opt/app/data/test/e2e/chat-exchange.spec.ts ] || [ ! -f /opt/app/data/test/e2e/chat-detail.spec.ts ] || [ ! -f /opt/app/data/test/e2e/chats-list.spec.ts ] || [ ! -f /opt/app/data/test/e2e/sign-in-helper.ts ] || [ ! -f /opt/app/data/test/e2e/sign-in.spec.ts ]; then
+          if [ ! -f /opt/app/data/package.json ] || [ ! -f /opt/app/data/pnpm-lock.yaml ] || [ ! -f /opt/app/data/test/e2e/fixtures.ts ] || [ ! -f /opt/app/data/test/e2e/multi-user-fixtures.ts ] || [ ! -f /opt/app/data/test/e2e/chat-api.ts ] || [ ! -f /opt/app/data/test/e2e/chat-exchange.spec.ts ] || [ ! -f /opt/app/data/test/e2e/chat-detail.spec.ts ] || [ ! -f /opt/app/data/test/e2e/chats-list.spec.ts ] || [ ! -f /opt/app/data/test/e2e/file-upload.spec.ts ] || [ ! -f /opt/app/data/test/e2e/sign-in-helper.ts ] || [ ! -f /opt/app/data/test/e2e/sign-in.spec.ts ]; then
             echo "ERROR: File sync timed out (package.json, pnpm-lock.yaml, or test/e2e files not found after 120s)"
             exit 1
           fi

--- a/src/api/errors.test.ts
+++ b/src/api/errors.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { isThreadDegradedError } from './errors';
+
+const buildError = (data: unknown) => ({ response: { data } });
+
+describe('isThreadDegradedError', () => {
+  it('matches failed precondition with exact message', () => {
+    const error = buildError({ code: 'failed_precondition', message: 'thread is degraded' });
+    expect(isThreadDegradedError(error)).toBe(true);
+  });
+
+  it('normalizes camel case codes', () => {
+    const error = buildError({ code: 'FailedPrecondition', message: 'thread is degraded' });
+    expect(isThreadDegradedError(error)).toBe(true);
+  });
+
+  it('rejects non-matching messages', () => {
+    const error = buildError({ code: 'failed_precondition', message: 'Thread is degraded' });
+    expect(isThreadDegradedError(error)).toBe(false);
+  });
+
+  it('parses JSON payloads', () => {
+    const error = buildError(JSON.stringify({ code: 'failed_precondition', message: 'thread is degraded' }));
+    expect(isThreadDegradedError(error)).toBe(true);
+  });
+});

--- a/src/api/errors.test.ts
+++ b/src/api/errors.test.ts
@@ -9,6 +9,20 @@ describe('isThreadDegradedError', () => {
     expect(isThreadDegradedError(error)).toBe(true);
   });
 
+  it('prefers top-level fields over nested error payload', () => {
+    const error = buildError({
+      code: 'failed_precondition',
+      message: 'thread is degraded',
+      error: { code: 'permission_denied', message: 'not degraded' },
+    });
+    expect(isThreadDegradedError(error)).toBe(true);
+  });
+
+  it('falls back to nested error payload', () => {
+    const error = buildError({ error: { code: 'failed_precondition', message: 'thread is degraded' } });
+    expect(isThreadDegradedError(error)).toBe(true);
+  });
+
   it('normalizes camel case codes', () => {
     const error = buildError({ code: 'FailedPrecondition', message: 'thread is degraded' });
     expect(isThreadDegradedError(error)).toBe(true);

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -1,5 +1,16 @@
 import type { ApiError } from '@/api/http';
 
+type ConnectErrorPayload = {
+  code?: unknown;
+  message?: unknown;
+  error?: unknown;
+};
+
+type ConnectErrorDetails = {
+  code?: string;
+  message?: string;
+};
+
 export function resolveErrorMessage(error: unknown, fallback: string): string {
   const maybeApiError = error as ApiError;
   const payload = maybeApiError?.response?.data as { error?: unknown; message?: unknown } | undefined;
@@ -8,4 +19,58 @@ export function resolveErrorMessage(error: unknown, fallback: string): string {
   if (maybeApiError?.message && typeof maybeApiError.message === 'string') return maybeApiError.message;
   if (error instanceof Error && typeof error.message === 'string') return error.message;
   return fallback;
+}
+
+const normalizeConnectCode = (code: string): string => {
+  return code
+    .replace(/([a-z])([A-Z])/g, '$1_$2')
+    .replace(/[-\s]+/g, '_')
+    .toLowerCase();
+};
+
+const resolveConnectPayload = (data: unknown): ConnectErrorPayload | null => {
+  if (!data) return null;
+  if (typeof data === 'string') {
+    const trimmed = data.trim();
+    if (!trimmed) return null;
+    if (!trimmed.startsWith('{')) return null;
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (parsed && typeof parsed === 'object') {
+        return parsed as ConnectErrorPayload;
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+
+  if (typeof data === 'object') return data as ConnectErrorPayload;
+  return null;
+};
+
+export function resolveConnectErrorDetails(error: unknown): ConnectErrorDetails | null {
+  const maybeApiError = error as ApiError;
+  const payload = resolveConnectPayload(maybeApiError?.response?.data);
+  if (!payload) return null;
+
+  const nestedPayload = typeof payload.error === 'object' && payload.error !== null
+    ? (payload.error as ConnectErrorPayload)
+    : payload;
+
+  const code = typeof nestedPayload.code === 'string' ? nestedPayload.code : undefined;
+  const message = typeof nestedPayload.message === 'string'
+    ? nestedPayload.message
+    : typeof nestedPayload.error === 'string'
+      ? nestedPayload.error
+      : undefined;
+
+  if (!code && !message) return null;
+  return { code, message };
+}
+
+export function isThreadDegradedError(error: unknown): boolean {
+  const details = resolveConnectErrorDetails(error);
+  if (!details?.code || details.message !== 'thread is degraded') return false;
+  return normalizeConnectCode(details.code) === 'failed_precondition';
 }

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -54,16 +54,26 @@ export function resolveConnectErrorDetails(error: unknown): ConnectErrorDetails 
   const payload = resolveConnectPayload(maybeApiError?.response?.data);
   if (!payload) return null;
 
-  const nestedPayload = typeof payload.error === 'object' && payload.error !== null
-    ? (payload.error as ConnectErrorPayload)
-    : payload;
-
-  const code = typeof nestedPayload.code === 'string' ? nestedPayload.code : undefined;
-  const message = typeof nestedPayload.message === 'string'
-    ? nestedPayload.message
-    : typeof nestedPayload.error === 'string'
-      ? nestedPayload.error
+  let code = typeof payload.code === 'string' ? payload.code : undefined;
+  let message = typeof payload.message === 'string'
+    ? payload.message
+    : typeof payload.error === 'string'
+      ? payload.error
       : undefined;
+
+  if ((!code || !message) && typeof payload.error === 'object' && payload.error !== null) {
+    const nestedPayload = payload.error as ConnectErrorPayload;
+    if (!code && typeof nestedPayload.code === 'string') {
+      code = nestedPayload.code;
+    }
+    if (!message) {
+      message = typeof nestedPayload.message === 'string'
+        ? nestedPayload.message
+        : typeof nestedPayload.error === 'string'
+          ? nestedPayload.error
+          : undefined;
+    }
+  }
 
   if (!code && !message) return null;
   return { code, message };

--- a/src/components/screens/ChatsScreen.tsx
+++ b/src/components/screens/ChatsScreen.tsx
@@ -6,6 +6,7 @@ import {
   MessageSquarePlus,
   Circle,
   CheckCircle,
+  AlertTriangle,
   ChevronDown,
   Trash2,
   LogOut,
@@ -271,6 +272,20 @@ type ChatDetailHeaderProps = {
   onCancelReminder?: (reminderId: string) => void;
   cancellingReminderIds?: ReadonlySet<string>;
 };
+
+function ChatDegradedBanner() {
+  return (
+    <div
+      className="border-b border-[var(--agyn-status-pending)] bg-[var(--agyn-status-pending-bg)] px-4 py-2"
+      data-testid="chat-degraded-banner"
+    >
+      <div className="flex items-center gap-2 text-sm text-[var(--agyn-status-pending)]">
+        <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+        <span>This thread is degraded and is now read-only.</span>
+      </div>
+    </div>
+  );
+}
 
 function ChatDetailHeader({
   chat,
@@ -571,6 +586,7 @@ interface ChatsScreenProps {
   onUpdateSummary?: (chatId: string, summary: string) => void;
   isUpdateSummaryPending?: boolean;
   isSendMessagePending?: boolean;
+  isThreadDegraded?: boolean;
   currentUserId: string;
   draftMode?: boolean;
   draftParticipants?: DraftParticipant[];
@@ -617,6 +633,7 @@ export default function ChatsScreen({
   onUpdateSummary,
   isUpdateSummaryPending = false,
   isSendMessagePending = false,
+  isThreadDegraded = false,
   currentUserId,
   draftMode = false,
   draftParticipants = [],
@@ -680,7 +697,15 @@ export default function ChatsScreen({
     );
   };
 
-  const renderComposer = ({ baseDisabled, trimmedLength }: { baseDisabled: boolean; trimmedLength: number }) => {
+  const renderComposer = ({
+    baseDisabled,
+    trimmedLength,
+    composerDisabled = false,
+  }: {
+    baseDisabled: boolean;
+    trimmedLength: number;
+    composerDisabled?: boolean;
+  }) => {
     const lengthExceeded = trimmedLength > CHAT_MESSAGE_MAX_LENGTH;
     const nearLimit = trimmedLength >= NEAR_LIMIT_THRESHOLD && !lengthExceeded;
     const sendDisabled = baseDisabled || lengthExceeded || isUploading;
@@ -700,6 +725,7 @@ export default function ChatsScreen({
             onSendMessage(inputValue, { chatId: selectedChatId ?? null });
           }}
           sendDisabled={sendDisabled}
+          disabled={composerDisabled}
           isSending={isSendMessagePending}
           attachments={attachments}
           onAttachFiles={onAttachFiles}
@@ -780,6 +806,7 @@ export default function ChatsScreen({
           onCancelReminder={onCancelReminder}
           cancellingReminderIds={cancellingReminderIds}
         />
+        {isThreadDegraded ? <ChatDegradedBanner /> : null}
 
         <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
           <Chat
@@ -797,8 +824,9 @@ export default function ChatsScreen({
         </div>
 
         {renderComposer({
-          baseDisabled: !onSendMessage || !selectedChatId || isSendMessagePending,
+          baseDisabled: !onSendMessage || !selectedChatId || isSendMessagePending || isThreadDegraded,
           trimmedLength: chatTrimmedLength,
+          composerDisabled: isThreadDegraded,
         })}
         {isLoading ? (
           <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/80 backdrop-blur-sm">

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -7,6 +7,7 @@ import { MarkdownContent } from '@/components/MarkdownContent';
 import { MessageAttachments } from '@/components/MessageAttachments';
 import ChatsScreen, { UserMenu } from '@/components/screens/ChatsScreen';
 import { notifyError } from '@/lib/notify';
+import { isThreadDegradedError } from '@/api/errors';
 import { useUser } from '@/user/user.runtime';
 import { useOrganization } from '@/organization/organization.runtime';
 import { useFileAttachments } from '@/hooks/useFileAttachments';
@@ -100,6 +101,7 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
   const [selectedChatIdState, setSelectedChatIdState] = useState<string | null>(params.chatId ?? null);
   const [cancellingReminderIds, setCancellingReminderIds] = useState<ReadonlySet<string>>(() => new Set());
   const [deletedMessageIds, setDeletedMessageIds] = useState<ReadonlySet<string>>(() => new Set());
+  const [degradedChatIds, setDegradedChatIds] = useState<ReadonlySet<string>>(() => new Set());
 
   const selectedChatId = params.chatId ?? selectedChatIdState;
   const previousOrganizationIdRef = useRef<string | null>(selectedOrganizationId ?? null);
@@ -118,6 +120,10 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
     }
     previousOrganizationIdRef.current = selectedOrganizationId ?? null;
   }, [selectedOrganizationId, navigate]);
+
+  useEffect(() => {
+    setDegradedChatIds(new Set());
+  }, [selectedOrganizationId]);
 
   const {
     attachments,
@@ -170,6 +176,7 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
 
   const effectiveDraftMode = isDraftSelectedState;
   const canUpdateChat = Boolean(selectedChatId && !effectiveDraftMode);
+  const isThreadDegraded = Boolean(selectedChatId && !effectiveDraftMode && degradedChatIds.has(selectedChatId));
 
   useChatNotifications({
     identityId: currentUserId,
@@ -183,6 +190,27 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
   useEffect(() => {
     setDeletedMessageIds(new Set());
   }, [selectedChatId]);
+
+  const markChatDegraded = useCallback((chatId: string) => {
+    if (!chatId || isDraftChatId(chatId)) return;
+    setDegradedChatIds((prev) => {
+      if (prev.has(chatId)) return prev;
+      const next = new Set(prev);
+      next.add(chatId);
+      return next;
+    });
+  }, []);
+
+  const handleSendMessageError = useCallback(
+    (error: unknown, chatId: string) => {
+      if (isThreadDegradedError(error)) {
+        markChatDegraded(chatId);
+        return;
+      }
+      notifyError(error instanceof Error ? error.message : 'Failed to send message.');
+    },
+    [markChatDegraded],
+  );
 
   const agents = useMemo(() => agentsQuery.data?.agents ?? [], [agentsQuery.data]);
   const agentIdSet = useMemo(() => new Set(agents.map((agent) => agent.meta.id)), [agents]);
@@ -670,6 +698,7 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
                   onSuccess: () => {
                     setInputValue('');
                   },
+                  onError: (error) => handleSendMessageError(error, newChatId),
                 },
               );
             },
@@ -701,9 +730,7 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
             latestInputValueRef.current = '';
             void queryClient.invalidateQueries({ queryKey: ['chats', chatId, 'queued'] });
           },
-          onError: (error) => {
-            notifyError(error instanceof Error ? error.message : 'Failed to send message.');
-          },
+          onError: (error) => handleSendMessageError(error, chatId),
         },
       );
     },
@@ -724,6 +751,7 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
       lastNonDraftIdRef,
       lastPersistedTextRef,
       latestInputValueRef,
+      handleSendMessageError,
     ],
   );
 
@@ -787,6 +815,7 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
           isUpdateSummaryPending={canUpdateChat ? updateChat.isPending : false}
           currentUserId={currentUserId}
           isSendMessagePending={sendMessage.isPending || createChat.isPending}
+          isThreadDegraded={isThreadDegraded}
           draftMode={effectiveDraftMode}
           draftParticipants={draftParticipants}
           draftFetchOptions={draftFetchOptions}

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -192,7 +192,6 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
   }, [selectedChatId]);
 
   const markChatDegraded = useCallback((chatId: string) => {
-    if (!chatId || isDraftChatId(chatId)) return;
     setDegradedChatIds((prev) => {
       if (prev.has(chatId)) return prev;
       const next = new Set(prev);


### PR DESCRIPTION
## Summary
- detect degraded thread errors from SendMessage responses
- show a degraded banner and disable the composer for read-only chats
- add error parsing tests for degraded handling

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- VITE_API_BASE_URL=/api pnpm build

## Tracking
Part of https://github.com/agynio/agents-orchestrator/issues/148