### PR TITLE
fix: preserve diagram svg styles

### DIFF
--- a/src/components/MarkdownDiagram.tsx
+++ b/src/components/MarkdownDiagram.tsx
@@ -13,7 +13,7 @@ import { AlertTriangle } from 'lucide-react';
 import type { EmbedOptions } from 'vega-embed';
 import type { VisualizationSpec } from 'vega-lite';
 import { cn } from '@/lib/utils';
-import { sanitizeMarkdownHtml } from '@/lib/markdown/sanitize';
+import { sanitizeDiagramSvg } from '@/lib/markdown/sanitize';
 import { Alert, AlertDescription, AlertTitle } from './ui/alert';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './ui/collapsible';
 
@@ -151,7 +151,7 @@ function buildVegaTheme(isDark: boolean) {
 }
 
 function sanitizeSvgMarkup(svg: string): string | null {
-  const sanitized = sanitizeMarkdownHtml(svg);
+  const sanitized = sanitizeDiagramSvg(svg);
   if (!sanitized) return null;
   return sanitized.includes('<svg') ? sanitized : null;
 }

--- a/src/components/MarkdownDiagram.tsx
+++ b/src/components/MarkdownDiagram.tsx
@@ -151,9 +151,7 @@ function buildVegaTheme(isDark: boolean) {
 }
 
 function sanitizeSvgMarkup(svg: string): string | null {
-  const sanitized = sanitizeDiagramSvg(svg);
-  if (!sanitized) return null;
-  return sanitized.includes('<svg') ? sanitized : null;
+  return sanitizeDiagramSvg(svg);
 }
 
 function validateVegaLiteSpec(source: string): { spec?: VisualizationSpec; error?: string } {

--- a/src/lib/markdown/sanitize.test.ts
+++ b/src/lib/markdown/sanitize.test.ts
@@ -33,6 +33,72 @@ describe('sanitizeDiagramSvg', () => {
     expect(sanitized).not.toContain('@font-face');
     expect(sanitized).not.toContain('https://evil.com');
   });
+
+  it('drops CSS containing escapes', () => {
+    const svg = `
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <style>
+          .escaped { fill: u\\72 l(https://evil.com/escaped.png); }
+        </style>
+        <rect style="fill: u\\72 l(#gradient);"></rect>
+        <text class="escaped">Unsafe</text>
+      </svg>
+    `;
+
+    const sanitized = sanitizeDiagramSvg(svg);
+    expect(sanitized).not.toBeNull();
+    if (!sanitized) {
+      throw new Error('sanitizeDiagramSvg returned null');
+    }
+
+    const styleMatch = sanitized.match(/<style[^>]*>([\s\S]*?)<\/style>/);
+    expect(styleMatch?.[1].trim() ?? '').toBe('');
+    expect(sanitized).not.toContain('u\\72 l');
+    expect(sanitized).not.toContain('https://evil.com');
+    expect(sanitized).not.toContain('style="');
+  });
+
+  it('strips url values hidden with comments', () => {
+    const svg = `
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <style>
+          .commented { fill: u/**/rl(https://evil.com/commented.png); }
+        </style>
+        <text>Safe</text>
+      </svg>
+    `;
+
+    const sanitized = sanitizeDiagramSvg(svg);
+    expect(sanitized).not.toBeNull();
+    if (!sanitized) {
+      throw new Error('sanitizeDiagramSvg returned null');
+    }
+
+    expect(sanitized).toContain('<style>');
+    expect(sanitized).not.toContain('https://evil.com');
+    expect(sanitized).not.toContain('url(');
+  });
+
+  it('extracts only the sanitized svg root', () => {
+    const svg = `
+      <style>.global { color: red; }</style>
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <text>Safe</text>
+      </svg>
+      <div>Ignored</div>
+    `;
+
+    const sanitized = sanitizeDiagramSvg(svg);
+    expect(sanitized).not.toBeNull();
+    if (!sanitized) {
+      throw new Error('sanitizeDiagramSvg returned null');
+    }
+
+    expect(sanitized.startsWith('<svg')).toBe(true);
+    expect(sanitized).toContain('<text>Safe</text>');
+    expect(sanitized).not.toContain('<style>');
+    expect(sanitized).not.toContain('<div>');
+  });
 });
 
 describe('sanitizeMarkdownHtml', () => {

--- a/src/lib/markdown/sanitize.test.ts
+++ b/src/lib/markdown/sanitize.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeDiagramSvg, sanitizeMarkdownHtml } from './sanitize';
+
+describe('sanitizeDiagramSvg', () => {
+  it('keeps safe SVG styles and strips unsafe CSS', () => {
+    const svg = `
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <style>
+          .label { text-anchor: middle; }
+          @import url("https://evil.com/style.css");
+          @font-face { font-family: "Evil"; src: url("https://evil.com/font.woff"); }
+          .safe { fill: url(#gradient); }
+          .unsafe { fill: url("https://evil.com/image.png"); }
+        </style>
+        <defs>
+          <linearGradient id="gradient"></linearGradient>
+        </defs>
+        <rect style="fill: url(#gradient); stroke: url(https://evil.com/stroke.png);"></rect>
+        <text class="label">Hello</text>
+      </svg>
+    `;
+
+    const sanitized = sanitizeDiagramSvg(svg);
+    expect(sanitized).not.toBeNull();
+    if (!sanitized) {
+      throw new Error('sanitizeDiagramSvg returned null');
+    }
+
+    expect(sanitized).toContain('<style>');
+    expect(sanitized).toContain('text-anchor: middle');
+    expect(sanitized).toContain('url(#gradient)');
+    expect(sanitized).not.toContain('@import');
+    expect(sanitized).not.toContain('@font-face');
+    expect(sanitized).not.toContain('https://evil.com');
+  });
+});
+
+describe('sanitizeMarkdownHtml', () => {
+  it('strips style tags from user-provided HTML', () => {
+    const html = '<p>Hello</p><style>p{color:red}</style>';
+    const sanitized = sanitizeMarkdownHtml(html);
+    expect(sanitized).not.toBeNull();
+    if (!sanitized) {
+      throw new Error('sanitizeMarkdownHtml returned null');
+    }
+    expect(sanitized).toContain('<p>Hello</p>');
+    expect(sanitized).not.toContain('<style>');
+  });
+});

--- a/src/lib/markdown/sanitize.ts
+++ b/src/lib/markdown/sanitize.ts
@@ -4,7 +4,7 @@ import rehypeSanitize from 'rehype-sanitize';
 import rehypeStringify from 'rehype-stringify';
 import { unified } from 'unified';
 
-const allowedTagNames: Schema['tagNames'] = [
+const markdownTagNames: Schema['tagNames'] = [
   'a',
   'blockquote',
   'br',
@@ -37,6 +37,9 @@ const allowedTagNames: Schema['tagNames'] = [
   'tr',
   'th',
   'td',
+];
+
+const svgTagNames: Schema['tagNames'] = [
   'svg',
   'g',
   'path',
@@ -62,234 +65,316 @@ const allowedTagNames: Schema['tagNames'] = [
   'desc',
 ];
 
+const diagramSvgTagNames: Schema['tagNames'] = [...svgTagNames, 'style'];
+const allowedTagNames: Schema['tagNames'] = [...markdownTagNames, ...svgTagNames];
+
 const allowedProtocols: string[] = ['http', 'https', 'mailto'];
+
+const markdownAttributes: Schema['attributes'] = {
+  a: [
+    'href',
+    ['target', '_blank', '_self'],
+    ['rel', 'noopener', 'noreferrer', 'nofollow'],
+  ],
+  code: [
+    ['className', /^language-[\w-]+$/],
+  ],
+  img: ['src', 'alt', 'title', 'width', 'height', 'loading'],
+  ol: [
+    ['start', /^-?\d+$/],
+    ['type', '1', 'a', 'A', 'i', 'I'],
+    'reversed',
+  ],
+  li: [
+    ['value', /^-?\d+$/],
+  ],
+  video: ['src', 'controls', 'preload', 'width', 'height', 'poster'],
+  audio: ['src', 'controls', 'preload'],
+  source: ['src', 'type'],
+  th: ['align'],
+  td: ['align'],
+};
+
+const svgAttributes: Schema['attributes'] = {
+  svg: [
+    'className',
+    'id',
+    'role',
+    'aria-label',
+    'aria-hidden',
+    'focusable',
+    'width',
+    'height',
+    'viewBox',
+    'preserveAspectRatio',
+    'xmlns',
+    'xmlnsXLink',
+    'xmlnsXlink',
+    'style',
+  ],
+  g: [
+    'className',
+    'id',
+    'transform',
+    'fill',
+    'fillOpacity',
+    'stroke',
+    'strokeWidth',
+    'strokeDasharray',
+    'strokeLinecap',
+    'strokeLinejoin',
+    'strokeMiterlimit',
+    'strokeOpacity',
+    'opacity',
+    'style',
+    'clipPath',
+  ],
+  path: [
+    'className',
+    'id',
+    'd',
+    'fill',
+    'fillOpacity',
+    'stroke',
+    'strokeWidth',
+    'strokeDasharray',
+    'strokeLinecap',
+    'strokeLinejoin',
+    'strokeMiterlimit',
+    'strokeOpacity',
+    'opacity',
+    'style',
+    'markerEnd',
+    'markerStart',
+    'markerMid',
+    'transform',
+  ],
+  rect: [
+    'className',
+    'id',
+    'x',
+    'y',
+    'width',
+    'height',
+    'rx',
+    'ry',
+    'fill',
+    'fillOpacity',
+    'stroke',
+    'strokeWidth',
+    'strokeOpacity',
+    'opacity',
+    'style',
+    'transform',
+  ],
+  circle: [
+    'className',
+    'id',
+    'cx',
+    'cy',
+    'r',
+    'fill',
+    'fillOpacity',
+    'stroke',
+    'strokeWidth',
+    'strokeOpacity',
+    'opacity',
+    'style',
+    'transform',
+  ],
+  ellipse: [
+    'className',
+    'id',
+    'cx',
+    'cy',
+    'rx',
+    'ry',
+    'fill',
+    'fillOpacity',
+    'stroke',
+    'strokeWidth',
+    'strokeOpacity',
+    'opacity',
+    'style',
+    'transform',
+  ],
+  line: [
+    'className',
+    'id',
+    'x1',
+    'y1',
+    'x2',
+    'y2',
+    'stroke',
+    'strokeWidth',
+    'strokeDasharray',
+    'strokeOpacity',
+    'opacity',
+    'style',
+    'transform',
+  ],
+  polyline: [
+    'className',
+    'id',
+    'points',
+    'fill',
+    'fillOpacity',
+    'stroke',
+    'strokeWidth',
+    'strokeDasharray',
+    'strokeOpacity',
+    'opacity',
+    'style',
+    'transform',
+  ],
+  polygon: [
+    'className',
+    'id',
+    'points',
+    'fill',
+    'fillOpacity',
+    'stroke',
+    'strokeWidth',
+    'strokeDasharray',
+    'strokeOpacity',
+    'opacity',
+    'style',
+    'transform',
+  ],
+  text: [
+    'className',
+    'id',
+    'x',
+    'y',
+    'dx',
+    'dy',
+    'textAnchor',
+    'dominantBaseline',
+    'alignmentBaseline',
+    'fontFamily',
+    'fontSize',
+    'fontWeight',
+    'fill',
+    'fillOpacity',
+    'opacity',
+    'style',
+    'transform',
+  ],
+  tspan: [
+    'className',
+    'id',
+    'x',
+    'y',
+    'dx',
+    'dy',
+    'textAnchor',
+    'dominantBaseline',
+    'alignmentBaseline',
+    'fontFamily',
+    'fontSize',
+    'fontWeight',
+    'fill',
+    'fillOpacity',
+    'opacity',
+    'style',
+    'transform',
+  ],
+  defs: ['id'],
+  clipPath: ['id', 'clipPathUnits'],
+  mask: ['id', 'maskUnits', 'maskContentUnits'],
+  pattern: ['id', 'x', 'y', 'width', 'height', 'patternUnits', 'patternContentUnits'],
+  marker: ['id', 'markerWidth', 'markerHeight', 'refX', 'refY', 'orient', 'markerUnits', 'viewBox'],
+  linearGradient: ['id', 'x1', 'y1', 'x2', 'y2', 'gradientUnits', 'gradientTransform'],
+  radialGradient: ['id', 'cx', 'cy', 'r', 'fx', 'fy', 'gradientUnits', 'gradientTransform'],
+  stop: ['offset', 'stopColor', 'stopOpacity'],
+  symbol: ['id', 'viewBox', 'preserveAspectRatio'],
+  use: ['xLinkHref', 'xlinkHref', 'x', 'y', 'width', 'height'],
+  title: ['id'],
+  desc: ['id'],
+};
 
 export const markdownSanitizeSchema: Schema = {
   tagNames: allowedTagNames,
   attributes: {
-    a: [
-      'href',
-      ['target', '_blank', '_self'],
-      ['rel', 'noopener', 'noreferrer', 'nofollow'],
-    ],
-    code: [
-      ['className', /^language-[\w-]+$/],
-    ],
-    img: ['src', 'alt', 'title', 'width', 'height', 'loading'],
-    ol: [
-      ['start', /^-?\d+$/],
-      ['type', '1', 'a', 'A', 'i', 'I'],
-      'reversed',
-    ],
-    li: [
-      ['value', /^-?\d+$/],
-    ],
-    video: ['src', 'controls', 'preload', 'width', 'height', 'poster'],
-    audio: ['src', 'controls', 'preload'],
-    source: ['src', 'type'],
-    th: ['align'],
-    td: ['align'],
-    svg: [
-      'className',
-      'id',
-      'role',
-      'aria-label',
-      'aria-hidden',
-      'focusable',
-      'width',
-      'height',
-      'viewBox',
-      'preserveAspectRatio',
-      'xmlns',
-      'xmlnsXlink',
-      'style',
-    ],
-    g: [
-      'className',
-      'id',
-      'transform',
-      'fill',
-      'fillOpacity',
-      'stroke',
-      'strokeWidth',
-      'strokeDasharray',
-      'strokeLinecap',
-      'strokeLinejoin',
-      'strokeMiterlimit',
-      'strokeOpacity',
-      'opacity',
-      'style',
-      'clipPath',
-    ],
-    path: [
-      'className',
-      'id',
-      'd',
-      'fill',
-      'fillOpacity',
-      'stroke',
-      'strokeWidth',
-      'strokeDasharray',
-      'strokeLinecap',
-      'strokeLinejoin',
-      'strokeMiterlimit',
-      'strokeOpacity',
-      'opacity',
-      'style',
-      'markerEnd',
-      'markerStart',
-      'markerMid',
-      'transform',
-    ],
-    rect: [
-      'className',
-      'id',
-      'x',
-      'y',
-      'width',
-      'height',
-      'rx',
-      'ry',
-      'fill',
-      'fillOpacity',
-      'stroke',
-      'strokeWidth',
-      'strokeOpacity',
-      'opacity',
-      'style',
-      'transform',
-    ],
-    circle: [
-      'className',
-      'id',
-      'cx',
-      'cy',
-      'r',
-      'fill',
-      'fillOpacity',
-      'stroke',
-      'strokeWidth',
-      'strokeOpacity',
-      'opacity',
-      'style',
-      'transform',
-    ],
-    ellipse: [
-      'className',
-      'id',
-      'cx',
-      'cy',
-      'rx',
-      'ry',
-      'fill',
-      'fillOpacity',
-      'stroke',
-      'strokeWidth',
-      'strokeOpacity',
-      'opacity',
-      'style',
-      'transform',
-    ],
-    line: [
-      'className',
-      'id',
-      'x1',
-      'y1',
-      'x2',
-      'y2',
-      'stroke',
-      'strokeWidth',
-      'strokeDasharray',
-      'strokeOpacity',
-      'opacity',
-      'style',
-      'transform',
-    ],
-    polyline: [
-      'className',
-      'id',
-      'points',
-      'fill',
-      'fillOpacity',
-      'stroke',
-      'strokeWidth',
-      'strokeDasharray',
-      'strokeOpacity',
-      'opacity',
-      'style',
-      'transform',
-    ],
-    polygon: [
-      'className',
-      'id',
-      'points',
-      'fill',
-      'fillOpacity',
-      'stroke',
-      'strokeWidth',
-      'strokeDasharray',
-      'strokeOpacity',
-      'opacity',
-      'style',
-      'transform',
-    ],
-    text: [
-      'className',
-      'id',
-      'x',
-      'y',
-      'dx',
-      'dy',
-      'textAnchor',
-      'dominantBaseline',
-      'alignmentBaseline',
-      'fontFamily',
-      'fontSize',
-      'fontWeight',
-      'fill',
-      'fillOpacity',
-      'opacity',
-      'style',
-      'transform',
-    ],
-    tspan: [
-      'className',
-      'id',
-      'x',
-      'y',
-      'dx',
-      'dy',
-      'textAnchor',
-      'dominantBaseline',
-      'alignmentBaseline',
-      'fontFamily',
-      'fontSize',
-      'fontWeight',
-      'fill',
-      'fillOpacity',
-      'opacity',
-      'style',
-      'transform',
-    ],
-    defs: ['id'],
-    clipPath: ['id', 'clipPathUnits'],
-    mask: ['id', 'maskUnits', 'maskContentUnits'],
-    pattern: ['id', 'x', 'y', 'width', 'height', 'patternUnits', 'patternContentUnits'],
-    marker: ['id', 'markerWidth', 'markerHeight', 'refX', 'refY', 'orient', 'markerUnits', 'viewBox'],
-    linearGradient: ['id', 'x1', 'y1', 'x2', 'y2', 'gradientUnits', 'gradientTransform'],
-    radialGradient: ['id', 'cx', 'cy', 'r', 'fx', 'fy', 'gradientUnits', 'gradientTransform'],
-    stop: ['offset', 'stopColor', 'stopOpacity'],
-    symbol: ['id', 'viewBox', 'preserveAspectRatio'],
-    use: ['xlinkHref', 'x', 'y', 'width', 'height'],
-    title: ['id'],
-    desc: ['id'],
+    ...markdownAttributes,
+    ...svgAttributes,
   },
   protocols: {
     href: [...allowedProtocols],
     src: ['http', 'https', 'agyn'],
+    xLinkHref: ['#'],
     xlinkHref: ['#'],
   },
 };
+
+const diagramSanitizeSchema: Schema = {
+  tagNames: diagramSvgTagNames,
+  attributes: {
+    ...svgAttributes,
+    style: ['type'],
+  },
+  protocols: {
+    xLinkHref: ['#'],
+    xlinkHref: ['#'],
+  },
+};
+
+type HastNode = {
+  type: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+  value?: string;
+};
+
+const cssImportPattern = /@import\s+[^;]+;?/gi;
+const cssFontFacePattern = /@font-face\s*{[\s\S]*?}/gi;
+const cssUrlPattern = /url\(([^)]+)\)/gi;
+
+function isSafeSvgUrl(value: string): boolean {
+  const trimmed = value.trim().replace(/^['"]|['"]$/g, '');
+  return trimmed.startsWith('#');
+}
+
+function sanitizeSvgCss(value: string): string {
+  const withoutAtRules = value.replace(cssImportPattern, '').replace(cssFontFacePattern, '');
+  return withoutAtRules.replace(cssUrlPattern, (match, urlValue) => {
+    return isSafeSvgUrl(urlValue) ? match : '';
+  });
+}
+
+function sanitizeSvgStyles(node: HastNode): void {
+  if (node.type === 'element') {
+    const properties = node.properties ?? {};
+    const styleValue = properties.style;
+    if (typeof styleValue === 'string') {
+      const sanitized = sanitizeSvgCss(styleValue);
+      if (sanitized.trim()) {
+        properties.style = sanitized;
+      } else {
+        delete properties.style;
+      }
+    }
+
+    if (node.tagName === 'style') {
+      for (const child of node.children ?? []) {
+        if (child.type === 'text' && typeof child.value === 'string') {
+          child.value = sanitizeSvgCss(child.value);
+        }
+      }
+    }
+  }
+
+  for (const child of node.children ?? []) {
+    sanitizeSvgStyles(child);
+  }
+}
+
+function rehypeDiagramCssFilter() {
+  return (tree: HastNode) => {
+    sanitizeSvgStyles(tree);
+  };
+}
 
 export function sanitizeMarkdownHtml(value: string): string | null {
   const trimmed = value.trim();
@@ -298,6 +383,23 @@ export function sanitizeMarkdownHtml(value: string): string | null {
     const file = unified()
       .use(rehypeParse, { fragment: true })
       .use(rehypeSanitize, markdownSanitizeSchema)
+      .use(rehypeStringify)
+      .processSync(trimmed);
+    const sanitized = String(file).trim();
+    return sanitized ? sanitized : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+export function sanitizeDiagramSvg(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const file = unified()
+      .use(rehypeParse, { fragment: true })
+      .use(rehypeSanitize, diagramSanitizeSchema)
+      .use(rehypeDiagramCssFilter)
       .use(rehypeStringify)
       .processSync(trimmed);
     const sanitized = String(file).trim();

--- a/src/lib/markdown/sanitize.ts
+++ b/src/lib/markdown/sanitize.ts
@@ -1,3 +1,4 @@
+import type { Element, ElementContent, Root, RootContent } from 'hast';
 import type { Schema } from 'hast-util-sanitize';
 import rehypeParse from 'rehype-parse';
 import rehypeSanitize from 'rehype-sanitize';
@@ -319,14 +320,8 @@ const diagramSanitizeSchema: Schema = {
   },
 };
 
-type HastNode = {
-  type: string;
-  tagName?: string;
-  properties?: Record<string, unknown>;
-  children?: HastNode[];
-  value?: string;
-};
-
+const cssCommentPattern = /\/\*[\s\S]*?\*\//g;
+const cssEscapePattern = /\\/;
 const cssImportPattern = /@import\s+[^;]+;?/gi;
 const cssFontFacePattern = /@font-face\s*{[\s\S]*?}/gi;
 const cssUrlPattern = /url\(([^)]+)\)/gi;
@@ -337,42 +332,72 @@ function isSafeSvgUrl(value: string): boolean {
 }
 
 function sanitizeSvgCss(value: string): string {
-  const withoutAtRules = value.replace(cssImportPattern, '').replace(cssFontFacePattern, '');
+  if (cssEscapePattern.test(value)) {
+    return '';
+  }
+  const withoutComments = value.replace(cssCommentPattern, '');
+  const withoutAtRules = withoutComments.replace(cssImportPattern, '').replace(cssFontFacePattern, '');
   return withoutAtRules.replace(cssUrlPattern, (match, urlValue) => {
     return isSafeSvgUrl(urlValue) ? match : '';
   });
 }
 
-function sanitizeSvgStyles(node: HastNode): void {
+function sanitizeSvgStyles(node: Root | Element): void {
   if (node.type === 'element') {
-    const properties = node.properties ?? {};
-    const styleValue = properties.style;
+    const properties = node.properties;
+    const styleValue = properties?.style;
     if (typeof styleValue === 'string') {
       const sanitized = sanitizeSvgCss(styleValue);
       if (sanitized.trim()) {
-        properties.style = sanitized;
+        node.properties = { ...(properties ?? {}), style: sanitized };
       } else {
-        delete properties.style;
+        const nextProperties = { ...(properties ?? {}) };
+        delete nextProperties.style;
+        node.properties = nextProperties;
       }
     }
 
     if (node.tagName === 'style') {
-      for (const child of node.children ?? []) {
-        if (child.type === 'text' && typeof child.value === 'string') {
+      for (const child of node.children) {
+        if (child.type === 'text') {
           child.value = sanitizeSvgCss(child.value);
         }
       }
     }
   }
 
-  for (const child of node.children ?? []) {
-    sanitizeSvgStyles(child);
+  for (const child of node.children) {
+    if (child.type === 'element') {
+      sanitizeSvgStyles(child);
+    }
   }
 }
 
 function rehypeDiagramCssFilter() {
-  return (tree: HastNode) => {
+  return (tree: Root) => {
     sanitizeSvgStyles(tree);
+  };
+}
+
+function findFirstSvg(node: Root | Element): Element | null {
+  if (node.type === 'element' && node.tagName === 'svg') {
+    return node;
+  }
+
+  const children = node.children as Array<RootContent | ElementContent>;
+  for (const child of children) {
+    if (child.type !== 'element') continue;
+    const match = findFirstSvg(child);
+    if (match) return match;
+  }
+
+  return null;
+}
+
+function rehypeDiagramSvgRoot() {
+  return (tree: Root) => {
+    const svgElement = findFirstSvg(tree);
+    tree.children = svgElement ? [svgElement] : [];
   };
 }
 
@@ -400,10 +425,11 @@ export function sanitizeDiagramSvg(value: string): string | null {
       .use(rehypeParse, { fragment: true })
       .use(rehypeSanitize, diagramSanitizeSchema)
       .use(rehypeDiagramCssFilter)
+      .use(rehypeDiagramSvgRoot)
       .use(rehypeStringify)
       .processSync(trimmed);
     const sanitized = String(file).trim();
-    return sanitized ? sanitized : null;
+    return sanitized.startsWith('<svg') ? sanitized : null;
   } catch (_error) {
     return null;
   }

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -184,14 +184,15 @@ test('renders Mermaid diagrams inline', async ({ page }) => {
   const messageItem = await openChatWithMessage(page, message, anchor);
   const mermaid = messageItem.getByTestId('markdown-mermaid');
   await expect(mermaid).toBeVisible({ timeout: 15000 });
-  await expect(mermaid.locator('svg')).toBeVisible({ timeout: 15000 });
-  const labels = mermaid.locator('text');
-  const labelCount = await labels.count();
-  expect(labelCount).toBeGreaterThan(0);
-  const textAnchor = await labels
-    .first()
-    .evaluate((node) => window.getComputedStyle(node).textAnchor);
-  expect(textAnchor).toBe('middle');
+  const svg = mermaid.locator('svg');
+  await expect(svg).toBeVisible({ timeout: 15000 });
+  const textAnchors = await svg.evaluate((node) => {
+    return Array.from(node.querySelectorAll('text')).map((text) =>
+      window.getComputedStyle(text).textAnchor,
+    );
+  });
+  expect(textAnchors.length).toBeGreaterThan(0);
+  expect(textAnchors).toContain('middle');
   await argosScreenshot(page, 'inline-mermaid-diagram');
 });
 

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -185,6 +185,13 @@ test('renders Mermaid diagrams inline', async ({ page }) => {
   const mermaid = messageItem.getByTestId('markdown-mermaid');
   await expect(mermaid).toBeVisible({ timeout: 15000 });
   await expect(mermaid.locator('svg')).toBeVisible({ timeout: 15000 });
+  const labels = mermaid.locator('text');
+  const labelCount = await labels.count();
+  expect(labelCount).toBeGreaterThan(0);
+  const textAnchor = await labels
+    .first()
+    .evaluate((node) => window.getComputedStyle(node).textAnchor);
+  expect(textAnchor).toBe('middle');
   await argosScreenshot(page, 'inline-mermaid-diagram');
 });
 


### PR DESCRIPTION
## Summary
- add diagram-only SVG sanitizer allowing safe <style> blocks
- filter SVG CSS URLs/@import/@font-face to keep diagrams aligned
- extend unit and Playwright coverage for Mermaid rendering

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- PR_IMAGE=chat-app:issue-77 devspace run test-e2e (2 flaky: organization-switching.spec.ts)

Resolves #77