### PR TITLE
fix: preserve Mermaid SVG styles

### DIFF
--- a/src/components/MarkdownDiagram.tsx
+++ b/src/components/MarkdownDiagram.tsx
@@ -273,8 +273,6 @@ export function MarkdownDiagram({ language, source, className = '' }: MarkdownDi
           securityLevel: 'strict',
           theme: isDark ? 'dark' : 'default',
           htmlLabels: false,
-          flowchart: { htmlLabels: false },
-          sequence: { htmlLabels: false },
         });
         const { svg } = await mermaid.render(diagramId, trimmedSource);
         if (cancelled) return;

--- a/src/components/MarkdownDiagram.tsx
+++ b/src/components/MarkdownDiagram.tsx
@@ -272,6 +272,7 @@ export function MarkdownDiagram({ language, source, className = '' }: MarkdownDi
           startOnLoad: false,
           securityLevel: 'strict',
           theme: isDark ? 'dark' : 'default',
+          htmlLabels: false,
           flowchart: { htmlLabels: false },
           sequence: { htmlLabels: false },
         });

--- a/src/lib/markdown/sanitize.test.ts
+++ b/src/lib/markdown/sanitize.test.ts
@@ -71,6 +71,16 @@ describe('sanitizeDiagramSvg', () => {
     const input = '<svg><rect style="fill:url(https://evil.test)" /></svg>';
     expect(sanitizeDiagramSvg(input)).toBeNull();
   });
+
+  it('rejects unsupported tags like foreignObject', () => {
+    const input = '<svg><foreignObject><div>Bad</div></foreignObject></svg>';
+    expect(sanitizeDiagramSvg(input)).toBeNull();
+  });
+
+  it('rejects external urls in presentation attributes', () => {
+    const input = '<svg><path filter="url (https://evil.test)" /></svg>';
+    expect(sanitizeDiagramSvg(input)).toBeNull();
+  });
 });
 
 describe('sanitizeMarkdownHtml', () => {

--- a/src/lib/markdown/sanitize.test.ts
+++ b/src/lib/markdown/sanitize.test.ts
@@ -1,103 +1,75 @@
+import rehypeParse from 'rehype-parse';
+import { unified } from 'unified';
 import { describe, expect, it } from 'vitest';
+import type { Element, Root } from 'hast';
 import { sanitizeDiagramSvg, sanitizeMarkdownHtml } from './sanitize';
 
+function parseRoot(markup: string): Root {
+  return unified().use(rehypeParse, { fragment: true }).parse(markup) as Root;
+}
+
+function elementChildren(node: Root | Element): Element[] {
+  return (node.children ?? []).filter((child): child is Element => child.type === 'element');
+}
+
 describe('sanitizeDiagramSvg', () => {
-  it('keeps safe SVG styles and strips unsafe CSS', () => {
-    const svg = `
-      <svg xmlns="http://www.w3.org/2000/svg">
-        <style>
-          .label { text-anchor: middle; }
-          @import url("https://evil.com/style.css");
-          @font-face { font-family: "Evil"; src: url("https://evil.com/font.woff"); }
-          .safe { fill: url(#gradient); }
-          .unsafe { fill: url("https://evil.com/image.png"); }
-        </style>
-        <defs>
-          <linearGradient id="gradient"></linearGradient>
-        </defs>
-        <rect style="fill: url(#gradient); stroke: url(https://evil.com/stroke.png);"></rect>
-        <text class="label">Hello</text>
-      </svg>
-    `;
+  it('moves top-level style into the svg root', () => {
+    const input =
+      '<style>.node{fill:#fff;}</style><svg viewBox="0 0 10 10"><rect width="10" height="10" /></svg>';
+    const sanitized = sanitizeDiagramSvg(input);
 
-    const sanitized = sanitizeDiagramSvg(svg);
     expect(sanitized).not.toBeNull();
-    if (!sanitized) {
-      throw new Error('sanitizeDiagramSvg returned null');
-    }
+    if (!sanitized) return;
 
-    expect(sanitized).toContain('<style>');
-    expect(sanitized).toContain('text-anchor: middle');
-    expect(sanitized).toContain('url(#gradient)');
-    expect(sanitized).not.toContain('@import');
-    expect(sanitized).not.toContain('@font-face');
-    expect(sanitized).not.toContain('https://evil.com');
+    expect(sanitized).toContain('fill:#fff');
+    const root = parseRoot(sanitized);
+    const rootElements = elementChildren(root);
+    expect(rootElements).toHaveLength(1);
+    expect(rootElements[0]?.tagName).toBe('svg');
+
+    const svgChildren = elementChildren(rootElements[0]);
+    expect(svgChildren.some((child) => child.tagName === 'style')).toBe(true);
   });
 
-  it('drops CSS containing escapes', () => {
-    const svg = `
-      <svg xmlns="http://www.w3.org/2000/svg">
-        <style>
-          .escaped { fill: u\\72 l(https://evil.com/escaped.png); }
-        </style>
-        <rect style="fill: u\\72 l(#gradient);"></rect>
-        <text class="escaped">Unsafe</text>
-      </svg>
-    `;
+  it('preserves filter tags, data attributes, and font style', () => {
+    const input = [
+      '<style>.node{filter:url(#shadow);}</style>',
+      '<svg viewBox="0 0 10 10">',
+      '  <defs>',
+      '    <filter id="shadow" x="0" y="0" width="1" height="1">',
+      '      <feDropShadow dx="1" dy="2" stdDeviation="3" flood-color="#000" flood-opacity="0.5" />',
+      '    </filter>',
+      '  </defs>',
+      '  <g data-id="node" data-look="handDrawn">',
+      '    <path d="M0 0" data-edge="1" data-et="edge" data-id="edge" data-points="0,0 1,1" />',
+      '  </g>',
+      '  <text font-style="italic">Hello</text>',
+      '</svg>',
+    ].join('');
+    const sanitized = sanitizeDiagramSvg(input);
 
-    const sanitized = sanitizeDiagramSvg(svg);
     expect(sanitized).not.toBeNull();
-    if (!sanitized) {
-      throw new Error('sanitizeDiagramSvg returned null');
-    }
-
-    const styleMatch = sanitized.match(/<style[^>]*>([\s\S]*?)<\/style>/);
-    expect(styleMatch?.[1].trim() ?? '').toBe('');
-    expect(sanitized).not.toContain('u\\72 l');
-    expect(sanitized).not.toContain('https://evil.com');
-    expect(sanitized).not.toContain('style="');
+    if (!sanitized) return;
+    expect(sanitized).toContain('<filter');
+    expect(sanitized).toContain('<feDropShadow');
+    expect(sanitized).toContain('data-edge');
+    expect(sanitized).toContain('font-style="italic"');
   });
 
-  it('strips url values hidden with comments', () => {
-    const svg = `
-      <svg xmlns="http://www.w3.org/2000/svg">
-        <style>
-          .commented { fill: u/**/rl(https://evil.com/commented.png); }
-        </style>
-        <text>Safe</text>
-      </svg>
-    `;
-
-    const sanitized = sanitizeDiagramSvg(svg);
-    expect(sanitized).not.toBeNull();
-    if (!sanitized) {
-      throw new Error('sanitizeDiagramSvg returned null');
-    }
-
-    expect(sanitized).toContain('<style>');
-    expect(sanitized).not.toContain('https://evil.com');
-    expect(sanitized).not.toContain('url(');
+  it('fails closed on unsafe css', () => {
+    const input = [
+      '<style>',
+      '@import url("https://evil.test");',
+      '@font-face { font-family: "Evil"; src: url("https://evil.test/font.woff"); }',
+      '</style>',
+      '<svg></svg>',
+    ].join('');
+    expect(sanitizeDiagramSvg(input)).toBeNull();
   });
 
-  it('extracts only the sanitized svg root', () => {
-    const svg = `
-      <style>.global { color: red; }</style>
-      <svg xmlns="http://www.w3.org/2000/svg">
-        <text>Safe</text>
-      </svg>
-      <div>Ignored</div>
-    `;
-
-    const sanitized = sanitizeDiagramSvg(svg);
-    expect(sanitized).not.toBeNull();
-    if (!sanitized) {
-      throw new Error('sanitizeDiagramSvg returned null');
-    }
-
-    expect(sanitized.startsWith('<svg')).toBe(true);
-    expect(sanitized).toContain('<text>Safe</text>');
-    expect(sanitized).not.toContain('<style>');
-    expect(sanitized).not.toContain('<div>');
+  it('rejects external urls in style attributes', () => {
+    const input = '<svg><rect style="fill:url(https://evil.test)" /></svg>';
+    expect(sanitizeDiagramSvg(input)).toBeNull();
   });
 });
 
@@ -106,9 +78,7 @@ describe('sanitizeMarkdownHtml', () => {
     const html = '<p>Hello</p><style>p{color:red}</style>';
     const sanitized = sanitizeMarkdownHtml(html);
     expect(sanitized).not.toBeNull();
-    if (!sanitized) {
-      throw new Error('sanitizeMarkdownHtml returned null');
-    }
+    if (!sanitized) return;
     expect(sanitized).toContain('<p>Hello</p>');
     expect(sanitized).not.toContain('<style>');
   });

--- a/src/lib/markdown/sanitize.ts
+++ b/src/lib/markdown/sanitize.ts
@@ -1,11 +1,11 @@
-import type { Element, ElementContent, Root, RootContent } from 'hast';
+import type { Element, Properties, Root, Text } from 'hast';
 import type { Schema } from 'hast-util-sanitize';
 import rehypeParse from 'rehype-parse';
 import rehypeSanitize from 'rehype-sanitize';
 import rehypeStringify from 'rehype-stringify';
 import { unified } from 'unified';
 
-const markdownTagNames: Schema['tagNames'] = [
+const htmlTagNames: Schema['tagNames'] = [
   'a',
   'blockquote',
   'br',
@@ -66,239 +66,235 @@ const svgTagNames: Schema['tagNames'] = [
   'desc',
 ];
 
-const diagramSvgTagNames: Schema['tagNames'] = [...svgTagNames, 'style'];
-const allowedTagNames: Schema['tagNames'] = [...markdownTagNames, ...svgTagNames];
+const diagramTagNames: Schema['tagNames'] = [
+  ...svgTagNames,
+  'style',
+  'filter',
+  'feDropShadow',
+];
 
 const allowedProtocols: string[] = ['http', 'https', 'mailto'];
 
-const markdownAttributes: Schema['attributes'] = {
-  a: [
-    'href',
-    ['target', '_blank', '_self'],
-    ['rel', 'noopener', 'noreferrer', 'nofollow'],
-  ],
-  code: [
-    ['className', /^language-[\w-]+$/],
-  ],
-  img: ['src', 'alt', 'title', 'width', 'height', 'loading'],
-  ol: [
-    ['start', /^-?\d+$/],
-    ['type', '1', 'a', 'A', 'i', 'I'],
-    'reversed',
-  ],
-  li: [
-    ['value', /^-?\d+$/],
-  ],
-  video: ['src', 'controls', 'preload', 'width', 'height', 'poster'],
-  audio: ['src', 'controls', 'preload'],
-  source: ['src', 'type'],
-  th: ['align'],
-  td: ['align'],
-};
-
-const svgAttributes: Schema['attributes'] = {
-  svg: [
-    'className',
-    'id',
-    'role',
-    'aria-label',
-    'aria-hidden',
-    'focusable',
-    'width',
-    'height',
-    'viewBox',
-    'preserveAspectRatio',
-    'xmlns',
-    'xmlnsXLink',
-    'xmlnsXlink',
-    'style',
-  ],
-  g: [
-    'className',
-    'id',
-    'transform',
-    'fill',
-    'fillOpacity',
-    'stroke',
-    'strokeWidth',
-    'strokeDasharray',
-    'strokeLinecap',
-    'strokeLinejoin',
-    'strokeMiterlimit',
-    'strokeOpacity',
-    'opacity',
-    'style',
-    'clipPath',
-  ],
-  path: [
-    'className',
-    'id',
-    'd',
-    'fill',
-    'fillOpacity',
-    'stroke',
-    'strokeWidth',
-    'strokeDasharray',
-    'strokeLinecap',
-    'strokeLinejoin',
-    'strokeMiterlimit',
-    'strokeOpacity',
-    'opacity',
-    'style',
-    'markerEnd',
-    'markerStart',
-    'markerMid',
-    'transform',
-  ],
-  rect: [
-    'className',
-    'id',
-    'x',
-    'y',
-    'width',
-    'height',
-    'rx',
-    'ry',
-    'fill',
-    'fillOpacity',
-    'stroke',
-    'strokeWidth',
-    'strokeOpacity',
-    'opacity',
-    'style',
-    'transform',
-  ],
-  circle: [
-    'className',
-    'id',
-    'cx',
-    'cy',
-    'r',
-    'fill',
-    'fillOpacity',
-    'stroke',
-    'strokeWidth',
-    'strokeOpacity',
-    'opacity',
-    'style',
-    'transform',
-  ],
-  ellipse: [
-    'className',
-    'id',
-    'cx',
-    'cy',
-    'rx',
-    'ry',
-    'fill',
-    'fillOpacity',
-    'stroke',
-    'strokeWidth',
-    'strokeOpacity',
-    'opacity',
-    'style',
-    'transform',
-  ],
-  line: [
-    'className',
-    'id',
-    'x1',
-    'y1',
-    'x2',
-    'y2',
-    'stroke',
-    'strokeWidth',
-    'strokeDasharray',
-    'strokeOpacity',
-    'opacity',
-    'style',
-    'transform',
-  ],
-  polyline: [
-    'className',
-    'id',
-    'points',
-    'fill',
-    'fillOpacity',
-    'stroke',
-    'strokeWidth',
-    'strokeDasharray',
-    'strokeOpacity',
-    'opacity',
-    'style',
-    'transform',
-  ],
-  polygon: [
-    'className',
-    'id',
-    'points',
-    'fill',
-    'fillOpacity',
-    'stroke',
-    'strokeWidth',
-    'strokeDasharray',
-    'strokeOpacity',
-    'opacity',
-    'style',
-    'transform',
-  ],
-  text: [
-    'className',
-    'id',
-    'x',
-    'y',
-    'dx',
-    'dy',
-    'textAnchor',
-    'dominantBaseline',
-    'alignmentBaseline',
-    'fontFamily',
-    'fontSize',
-    'fontWeight',
-    'fill',
-    'fillOpacity',
-    'opacity',
-    'style',
-    'transform',
-  ],
-  tspan: [
-    'className',
-    'id',
-    'x',
-    'y',
-    'dx',
-    'dy',
-    'textAnchor',
-    'dominantBaseline',
-    'alignmentBaseline',
-    'fontFamily',
-    'fontSize',
-    'fontWeight',
-    'fill',
-    'fillOpacity',
-    'opacity',
-    'style',
-    'transform',
-  ],
-  defs: ['id'],
-  clipPath: ['id', 'clipPathUnits'],
-  mask: ['id', 'maskUnits', 'maskContentUnits'],
-  pattern: ['id', 'x', 'y', 'width', 'height', 'patternUnits', 'patternContentUnits'],
-  marker: ['id', 'markerWidth', 'markerHeight', 'refX', 'refY', 'orient', 'markerUnits', 'viewBox'],
-  linearGradient: ['id', 'x1', 'y1', 'x2', 'y2', 'gradientUnits', 'gradientTransform'],
-  radialGradient: ['id', 'cx', 'cy', 'r', 'fx', 'fy', 'gradientUnits', 'gradientTransform'],
-  stop: ['offset', 'stopColor', 'stopOpacity'],
-  symbol: ['id', 'viewBox', 'preserveAspectRatio'],
-  use: ['xLinkHref', 'xlinkHref', 'x', 'y', 'width', 'height'],
-  title: ['id'],
-  desc: ['id'],
-};
-
 export const markdownSanitizeSchema: Schema = {
-  tagNames: allowedTagNames,
+  tagNames: [...htmlTagNames, ...svgTagNames],
   attributes: {
-    ...markdownAttributes,
-    ...svgAttributes,
+    a: [
+      'href',
+      ['target', '_blank', '_self'],
+      ['rel', 'noopener', 'noreferrer', 'nofollow'],
+    ],
+    code: [
+      ['className', /^language-[\w-]+$/],
+    ],
+    img: ['src', 'alt', 'title', 'width', 'height', 'loading'],
+    ol: [
+      ['start', /^-?\d+$/],
+      ['type', '1', 'a', 'A', 'i', 'I'],
+      'reversed',
+    ],
+    li: [
+      ['value', /^-?\d+$/],
+    ],
+    video: ['src', 'controls', 'preload', 'width', 'height', 'poster'],
+    audio: ['src', 'controls', 'preload'],
+    source: ['src', 'type'],
+    th: ['align'],
+    td: ['align'],
+    svg: [
+      'className',
+      'id',
+      'role',
+      'aria-label',
+      'aria-hidden',
+      'focusable',
+      'width',
+      'height',
+      'viewBox',
+      'preserveAspectRatio',
+      'xmlns',
+      'xmlnsXLink',
+      'xmlnsXlink',
+      'style',
+    ],
+    g: [
+      'className',
+      'id',
+      'transform',
+      'fill',
+      'fillOpacity',
+      'stroke',
+      'strokeWidth',
+      'strokeDasharray',
+      'strokeLinecap',
+      'strokeLinejoin',
+      'strokeMiterlimit',
+      'strokeOpacity',
+      'opacity',
+      'style',
+      'clipPath',
+    ],
+    path: [
+      'className',
+      'id',
+      'd',
+      'fill',
+      'fillOpacity',
+      'stroke',
+      'strokeWidth',
+      'strokeDasharray',
+      'strokeLinecap',
+      'strokeLinejoin',
+      'strokeMiterlimit',
+      'strokeOpacity',
+      'opacity',
+      'style',
+      'markerEnd',
+      'markerStart',
+      'markerMid',
+      'transform',
+    ],
+    rect: [
+      'className',
+      'id',
+      'x',
+      'y',
+      'width',
+      'height',
+      'rx',
+      'ry',
+      'fill',
+      'fillOpacity',
+      'stroke',
+      'strokeWidth',
+      'strokeOpacity',
+      'opacity',
+      'style',
+      'transform',
+    ],
+    circle: [
+      'className',
+      'id',
+      'cx',
+      'cy',
+      'r',
+      'fill',
+      'fillOpacity',
+      'stroke',
+      'strokeWidth',
+      'strokeOpacity',
+      'opacity',
+      'style',
+      'transform',
+    ],
+    ellipse: [
+      'className',
+      'id',
+      'cx',
+      'cy',
+      'rx',
+      'ry',
+      'fill',
+      'fillOpacity',
+      'stroke',
+      'strokeWidth',
+      'strokeOpacity',
+      'opacity',
+      'style',
+      'transform',
+    ],
+    line: [
+      'className',
+      'id',
+      'x1',
+      'y1',
+      'x2',
+      'y2',
+      'stroke',
+      'strokeWidth',
+      'strokeDasharray',
+      'strokeOpacity',
+      'opacity',
+      'style',
+      'transform',
+    ],
+    polyline: [
+      'className',
+      'id',
+      'points',
+      'fill',
+      'fillOpacity',
+      'stroke',
+      'strokeWidth',
+      'strokeDasharray',
+      'strokeOpacity',
+      'opacity',
+      'style',
+      'transform',
+    ],
+    polygon: [
+      'className',
+      'id',
+      'points',
+      'fill',
+      'fillOpacity',
+      'stroke',
+      'strokeWidth',
+      'strokeDasharray',
+      'strokeOpacity',
+      'opacity',
+      'style',
+      'transform',
+    ],
+    text: [
+      'className',
+      'id',
+      'x',
+      'y',
+      'dx',
+      'dy',
+      'textAnchor',
+      'dominantBaseline',
+      'alignmentBaseline',
+      'fontFamily',
+      'fontSize',
+      'fontWeight',
+      'fill',
+      'fillOpacity',
+      'opacity',
+      'style',
+      'transform',
+    ],
+    tspan: [
+      'className',
+      'id',
+      'x',
+      'y',
+      'dx',
+      'dy',
+      'textAnchor',
+      'dominantBaseline',
+      'alignmentBaseline',
+      'fontFamily',
+      'fontSize',
+      'fontWeight',
+      'fill',
+      'fillOpacity',
+      'opacity',
+      'style',
+      'transform',
+    ],
+    defs: ['id'],
+    clipPath: ['id', 'clipPathUnits'],
+    mask: ['id', 'maskUnits', 'maskContentUnits'],
+    pattern: ['id', 'x', 'y', 'width', 'height', 'patternUnits', 'patternContentUnits'],
+    marker: ['id', 'markerWidth', 'markerHeight', 'refX', 'refY', 'orient', 'markerUnits', 'viewBox'],
+    linearGradient: ['id', 'x1', 'y1', 'x2', 'y2', 'gradientUnits', 'gradientTransform'],
+    radialGradient: ['id', 'cx', 'cy', 'r', 'fx', 'fy', 'gradientUnits', 'gradientTransform'],
+    stop: ['offset', 'stopColor', 'stopOpacity'],
+    symbol: ['id', 'viewBox', 'preserveAspectRatio'],
+    use: ['xLinkHref', 'xlinkHref', 'x', 'y', 'width', 'height'],
+    title: ['id'],
+    desc: ['id'],
   },
   protocols: {
     href: [...allowedProtocols],
@@ -308,97 +304,184 @@ export const markdownSanitizeSchema: Schema = {
   },
 };
 
+const diagramBaseAttributes: NonNullable<Schema['attributes']> = markdownSanitizeSchema.attributes ?? {};
 const diagramSanitizeSchema: Schema = {
-  tagNames: diagramSvgTagNames,
+  tagNames: diagramTagNames,
   attributes: {
-    ...svgAttributes,
-    style: ['type'],
+    ...diagramBaseAttributes,
+    svg: [...(diagramBaseAttributes.svg ?? []), 'ariaRoleDescription', 'data*'],
+    g: [...(diagramBaseAttributes.g ?? []), 'data*', 'filter'],
+    path: [...(diagramBaseAttributes.path ?? []), 'data*', 'filter'],
+    rect: [...(diagramBaseAttributes.rect ?? []), 'data*', 'filter'],
+    circle: [...(diagramBaseAttributes.circle ?? []), 'data*', 'filter'],
+    ellipse: [...(diagramBaseAttributes.ellipse ?? []), 'data*', 'filter'],
+    line: [...(diagramBaseAttributes.line ?? []), 'data*', 'filter'],
+    polyline: [...(diagramBaseAttributes.polyline ?? []), 'data*', 'filter'],
+    polygon: [...(diagramBaseAttributes.polygon ?? []), 'data*', 'filter'],
+    text: [...(diagramBaseAttributes.text ?? []), 'data*', 'fontStyle', 'filter'],
+    tspan: [...(diagramBaseAttributes.tspan ?? []), 'data*', 'fontStyle', 'filter'],
+    filter: [
+      'id',
+      'x',
+      'y',
+      'width',
+      'height',
+      'filterUnits',
+      'primitiveUnits',
+      'colorInterpolationFilters',
+    ],
+    feDropShadow: ['dx', 'dy', 'stdDeviation', 'floodColor', 'floodOpacity', 'in', 'result'],
+    style: ['type', 'media'],
   },
-  protocols: {
-    xLinkHref: ['#'],
-    xlinkHref: ['#'],
-  },
+  protocols: markdownSanitizeSchema.protocols,
 };
 
 const cssCommentPattern = /\/\*[\s\S]*?\*\//g;
-const cssEscapePattern = /\\/;
-const cssImportPattern = /@import\s+[^;]+;?/gi;
-const cssFontFacePattern = /@font-face\s*{[\s\S]*?}/gi;
 const cssUrlPattern = /url\(([^)]+)\)/gi;
+const cssUnsafeAtRulePattern = /@import|@font-face/i;
+const cssLocalUrlPattern = /^#[\w:.-]+$/;
 
-function isSafeSvgUrl(value: string): boolean {
+function stripCssComments(css: string): string {
+  return css.replace(cssCommentPattern, '');
+}
+
+function isSafeLocalUrlReference(value: string): boolean {
   const trimmed = value.trim().replace(/^['"]|['"]$/g, '');
-  return trimmed.startsWith('#');
+  return cssLocalUrlPattern.test(trimmed);
 }
 
-function sanitizeSvgCss(value: string): string {
-  if (cssEscapePattern.test(value)) {
-    return '';
+function isSafeSvgCss(css: string): boolean {
+  if (!css) return true;
+  if (css.includes('\\')) return false;
+  const normalized = stripCssComments(css).toLowerCase();
+  if (cssUnsafeAtRulePattern.test(normalized)) return false;
+  if (!normalized.includes('url(')) return true;
+  const matches = [...normalized.matchAll(cssUrlPattern)];
+  if (matches.length === 0) return false;
+  return matches.every((match) => isSafeLocalUrlReference(match[1] ?? ''));
+}
+
+function assertSafeSvgCss(css: string): void {
+  if (!isSafeSvgCss(css)) {
+    throw new Error('Unsafe diagram CSS');
   }
-  const withoutComments = value.replace(cssCommentPattern, '');
-  const withoutAtRules = withoutComments.replace(cssImportPattern, '').replace(cssFontFacePattern, '');
-  return withoutAtRules.replace(cssUrlPattern, (match, urlValue) => {
-    return isSafeSvgUrl(urlValue) ? match : '';
-  });
 }
 
-function sanitizeSvgStyles(node: Root | Element): void {
-  if (node.type === 'element') {
-    const properties = node.properties;
-    const styleValue = properties?.style;
-    if (typeof styleValue === 'string') {
-      const sanitized = sanitizeSvgCss(styleValue);
-      if (sanitized.trim()) {
-        node.properties = { ...(properties ?? {}), style: sanitized };
-      } else {
-        const nextProperties = { ...(properties ?? {}) };
-        delete nextProperties.style;
-        node.properties = nextProperties;
+function assertSafePresentationAttributes(properties: Properties | undefined): void {
+  if (!properties) return;
+  const styleValue = properties.style;
+  if (typeof styleValue === 'string') {
+    assertSafeSvgCss(styleValue);
+  }
+
+  for (const [name, value] of Object.entries(properties)) {
+    if (name === 'style') continue;
+    if (typeof value !== 'string') continue;
+    const normalized = value.toLowerCase();
+    if (!normalized.includes('url(')) continue;
+    if (value.includes('\\')) {
+      throw new Error('Unsafe diagram URL');
+    }
+    const matches = [...normalized.matchAll(cssUrlPattern)];
+    if (matches.length === 0) {
+      throw new Error('Unsafe diagram URL');
+    }
+    for (const match of matches) {
+      if (!isSafeLocalUrlReference(match[1] ?? '')) {
+        throw new Error('Unsafe diagram URL');
       }
     }
-
-    if (node.tagName === 'style') {
-      for (const child of node.children) {
-        if (child.type === 'text') {
-          child.value = sanitizeSvgCss(child.value);
-        }
-      }
-    }
-  }
-
-  for (const child of node.children) {
-    if (child.type === 'element') {
-      sanitizeSvgStyles(child);
-    }
   }
 }
 
-function rehypeDiagramCssFilter() {
-  return (tree: Root) => {
-    sanitizeSvgStyles(tree);
+function collectStyleText(node: Element): string {
+  return (node.children ?? [])
+    .filter((child): child is Text => child.type === 'text')
+    .map((child) => (typeof child.value === 'string' ? child.value : ''))
+    .join('');
+}
+
+function isElement(node: unknown): node is Element {
+  return Boolean(node) && typeof node === 'object' && (node as Element).type === 'element';
+}
+
+function isStyleElement(node: Element): boolean {
+  return node.tagName === 'style';
+}
+
+function findFirstSvg(tree: Root): Element | null {
+  let svg: Element | null = null;
+
+  const visit = (node: Root | Element) => {
+    if (svg) return;
+    for (const child of node.children ?? []) {
+      if (!isElement(child)) continue;
+      if (child.tagName === 'svg') {
+        svg = child;
+        return;
+      }
+      visit(child);
+      if (svg) return;
+    }
   };
+
+  visit(tree);
+  return svg;
 }
 
-function findFirstSvg(node: Root | Element): Element | null {
-  if (node.type === 'element' && node.tagName === 'svg') {
-    return node;
-  }
+function ensureSafeDiagramTree(tree: Root): void {
+  const visit = (node: Root | Element) => {
+    for (const child of node.children ?? []) {
+      if (!isElement(child)) continue;
+      if (isStyleElement(child)) {
+        const css = collectStyleText(child);
+        assertSafeSvgCss(css);
+      }
+      assertSafePresentationAttributes(child.properties);
+      visit(child);
+    }
+  };
 
-  const children = node.children as Array<RootContent | ElementContent>;
-  for (const child of children) {
-    if (child.type !== 'element') continue;
-    const match = findFirstSvg(child);
-    if (match) return match;
-  }
+  visit(tree);
+}
 
-  return null;
+function moveTopLevelStylesIntoSvg(tree: Root, svg: Element): void {
+  const topLevelStyles = (tree.children ?? []).filter(
+    (child): child is Element => isElement(child) && isStyleElement(child),
+  );
+
+  if (topLevelStyles.length === 0) return;
+  const svgChildren = svg.children ?? [];
+  svg.children = [...topLevelStyles, ...svgChildren];
 }
 
 function rehypeDiagramSvgRoot() {
   return (tree: Root) => {
-    const svgElement = findFirstSvg(tree);
-    tree.children = svgElement ? [svgElement] : [];
+    ensureSafeDiagramTree(tree);
+    const svg = findFirstSvg(tree);
+    if (!svg) {
+      throw new Error('Diagram output missing svg root');
+    }
+    moveTopLevelStylesIntoSvg(tree, svg);
+    tree.children = [svg];
   };
+}
+
+export function sanitizeDiagramSvg(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const file = unified()
+      .use(rehypeParse, { fragment: true })
+      .use(rehypeSanitize, diagramSanitizeSchema)
+      .use(rehypeDiagramSvgRoot)
+      .use(rehypeStringify)
+      .processSync(trimmed);
+    const sanitized = String(file).trim();
+    return sanitized ? sanitized : null;
+  } catch (_error) {
+    return null;
+  }
 }
 
 export function sanitizeMarkdownHtml(value: string): string | null {
@@ -412,24 +495,6 @@ export function sanitizeMarkdownHtml(value: string): string | null {
       .processSync(trimmed);
     const sanitized = String(file).trim();
     return sanitized ? sanitized : null;
-  } catch (_error) {
-    return null;
-  }
-}
-
-export function sanitizeDiagramSvg(value: string): string | null {
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  try {
-    const file = unified()
-      .use(rehypeParse, { fragment: true })
-      .use(rehypeSanitize, diagramSanitizeSchema)
-      .use(rehypeDiagramCssFilter)
-      .use(rehypeDiagramSvgRoot)
-      .use(rehypeStringify)
-      .processSync(trimmed);
-    const sanitized = String(file).trim();
-    return sanitized.startsWith('<svg') ? sanitized : null;
   } catch (_error) {
     return null;
   }

--- a/src/lib/markdown/sanitize.ts
+++ b/src/lib/markdown/sanitize.ts
@@ -73,6 +73,8 @@ const diagramTagNames: Schema['tagNames'] = [
   'feDropShadow',
 ];
 
+const diagramTagNameSet = new Set(diagramTagNames);
+
 const allowedProtocols: string[] = ['http', 'https', 'mailto'];
 
 export const markdownSanitizeSchema: Schema = {
@@ -337,12 +339,17 @@ const diagramSanitizeSchema: Schema = {
 };
 
 const cssCommentPattern = /\/\*[\s\S]*?\*\//g;
-const cssUrlPattern = /url\(([^)]+)\)/gi;
+const cssUrlPattern = /url\s*\(([^)]+)\)/gi;
 const cssUnsafeAtRulePattern = /@import|@font-face/i;
 const cssLocalUrlPattern = /^#[\w:.-]+$/;
 
 function stripCssComments(css: string): string {
   return css.replace(cssCommentPattern, '');
+}
+
+function collectCssUrlMatches(value: string): RegExpMatchArray[] {
+  cssUrlPattern.lastIndex = 0;
+  return [...value.matchAll(cssUrlPattern)];
 }
 
 function isSafeLocalUrlReference(value: string): boolean {
@@ -355,9 +362,8 @@ function isSafeSvgCss(css: string): boolean {
   if (css.includes('\\')) return false;
   const normalized = stripCssComments(css).toLowerCase();
   if (cssUnsafeAtRulePattern.test(normalized)) return false;
-  if (!normalized.includes('url(')) return true;
-  const matches = [...normalized.matchAll(cssUrlPattern)];
-  if (matches.length === 0) return false;
+  const matches = collectCssUrlMatches(normalized);
+  if (matches.length === 0) return true;
   return matches.every((match) => isSafeLocalUrlReference(match[1] ?? ''));
 }
 
@@ -378,14 +384,11 @@ function assertSafePresentationAttributes(properties: Properties | undefined): v
     if (name === 'style') continue;
     if (typeof value !== 'string') continue;
     const normalized = value.toLowerCase();
-    if (!normalized.includes('url(')) continue;
     if (value.includes('\\')) {
       throw new Error('Unsafe diagram URL');
     }
-    const matches = [...normalized.matchAll(cssUrlPattern)];
-    if (matches.length === 0) {
-      throw new Error('Unsafe diagram URL');
-    }
+    const matches = collectCssUrlMatches(normalized);
+    if (matches.length === 0) continue;
     for (const match of matches) {
       if (!isSafeLocalUrlReference(match[1] ?? '')) {
         throw new Error('Unsafe diagram URL');
@@ -407,6 +410,26 @@ function isElement(node: unknown): node is Element {
 
 function isStyleElement(node: Element): boolean {
   return node.tagName === 'style';
+}
+
+function ensureDiagramTagNames(tree: Root): void {
+  const visit = (node: Root | Element) => {
+    for (const child of node.children ?? []) {
+      if (!isElement(child)) continue;
+      if (!diagramTagNameSet.has(child.tagName)) {
+        throw new Error('Unsupported diagram markup');
+      }
+      visit(child);
+    }
+  };
+
+  visit(tree);
+}
+
+function rehypeDiagramTagValidator() {
+  return (tree: Root) => {
+    ensureDiagramTagNames(tree);
+  };
 }
 
 function findFirstSvg(tree: Root): Element | null {
@@ -473,6 +496,7 @@ export function sanitizeDiagramSvg(value: string): string | null {
   try {
     const file = unified()
       .use(rehypeParse, { fragment: true })
+      .use(rehypeDiagramTagValidator)
       .use(rehypeSanitize, diagramSanitizeSchema)
       .use(rehypeDiagramSvgRoot)
       .use(rehypeStringify)

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -197,6 +197,29 @@ test('renders Mermaid diagrams inline', async ({ page }) => {
   });
   expect(textAnchors.length).toBeGreaterThan(0);
   expect(textAnchors).toContain('middle');
+  const labelsInsideNodes = await svg.evaluate((node) => {
+    const groups = Array.from(node.querySelectorAll('g.node'));
+    const candidates = groups
+      .map((group) => ({
+        text: group.querySelector('text'),
+        shape: group.querySelector('rect, polygon, ellipse, circle'),
+      }))
+      .filter((entry) => entry.text && entry.shape);
+    if (candidates.length === 0) return false;
+    return candidates.every(({ text, shape }) => {
+      if (!text || !shape) return false;
+      const textBox = text.getBBox();
+      const shapeBox = shape.getBBox();
+      const padding = Math.max(4, Math.min(shapeBox.width, shapeBox.height) * 0.05);
+      return (
+        textBox.x >= shapeBox.x - padding &&
+        textBox.y >= shapeBox.y - padding &&
+        textBox.x + textBox.width <= shapeBox.x + shapeBox.width + padding &&
+        textBox.y + textBox.height <= shapeBox.y + shapeBox.height + padding
+      );
+    });
+  });
+  expect(labelsInsideNodes).toBe(true);
   await argosScreenshot(page, 'inline-mermaid-diagram');
 });
 

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -186,6 +186,10 @@ test('renders Mermaid diagrams inline', async ({ page }) => {
   await expect(mermaid).toBeVisible({ timeout: 15000 });
   const svg = mermaid.locator('svg');
   await expect(svg).toBeVisible({ timeout: 15000 });
+  await expect(svg.locator('style')).not.toHaveCount(0);
+  await expect(svg.locator('foreignObject')).toHaveCount(0);
+  await expect(svg.locator('filter')).not.toHaveCount(0);
+  await expect(svg.locator('feDropShadow')).not.toHaveCount(0);
   const textAnchors = await svg.evaluate((node) => {
     return Array.from(node.querySelectorAll('text')).map((text) =>
       window.getComputedStyle(text).textAnchor,


### PR DESCRIPTION
## Summary
- set Mermaid top-level htmlLabels to false
- add diagram-specific sanitizer to preserve style/filter/data attrs and move top-level styles into the SVG
- validate SVG CSS safety and add unit/e2e coverage

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- PR_IMAGE=chat-app:issue-79 devspace run test-e2e

Refs #79