### PR TITLE
fix(markdown): preserve diagram ids

### DIFF
--- a/src/lib/markdown/sanitize.test.ts
+++ b/src/lib/markdown/sanitize.test.ts
@@ -56,6 +56,28 @@ describe('sanitizeDiagramSvg', () => {
     expect(sanitized).toContain('font-style="italic"');
   });
 
+  it('does not prefix diagram ids', () => {
+    const input = [
+      '<style>#mermaid-diagram{fill:#fff;}</style>',
+      '<svg id="mermaid-diagram" viewBox="0 0 10 10">',
+      '  <defs>',
+      '    <marker id="marker-1" />',
+      '  </defs>',
+      '  <g id="node-1">',
+      '    <rect id="node-rect" width="10" height="10" />',
+      '  </g>',
+      '</svg>',
+    ].join('');
+    const sanitized = sanitizeDiagramSvg(input);
+
+    expect(sanitized).not.toBeNull();
+    if (!sanitized) return;
+    expect(sanitized).toContain('id="mermaid-diagram"');
+    expect(sanitized).toContain('id="marker-1"');
+    expect(sanitized).toContain('id="node-rect"');
+    expect(sanitized).not.toContain('user-content-');
+  });
+
   it('fails closed on unsafe css', () => {
     const input = [
       '<style>',

--- a/src/lib/markdown/sanitize.ts
+++ b/src/lib/markdown/sanitize.ts
@@ -336,6 +336,8 @@ const diagramSanitizeSchema: Schema = {
     style: ['type', 'media'],
   },
   protocols: markdownSanitizeSchema.protocols,
+  clobber: [],
+  clobberPrefix: '',
 };
 
 const cssCommentPattern = /\/\*[\s\S]*?\*\//g;

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -220,6 +220,22 @@ test('renders Mermaid diagrams inline', async ({ page }) => {
     });
   });
   expect(labelsInsideNodes).toBe(true);
+  const nodeColors = await svg.evaluate((node) => {
+    const shape = node.querySelector('g.node rect, g.node polygon, g.node ellipse, g.node circle');
+    if (!shape) return null;
+    const style = window.getComputedStyle(shape);
+    return {
+      fill: style.fill,
+      stroke: style.stroke,
+    };
+  });
+  expect(nodeColors).not.toBeNull();
+  if (nodeColors) {
+    expect(nodeColors.fill).not.toBe('none');
+    expect(nodeColors.fill).not.toBe('rgb(0, 0, 0)');
+    expect(nodeColors.stroke).not.toBe('none');
+    expect(nodeColors.stroke).not.toBe('rgb(0, 0, 0)');
+  }
   await argosScreenshot(page, 'inline-mermaid-diagram');
 });
 


### PR DESCRIPTION
## Summary
- disable rehype-sanitize id clobbering for diagram-only sanitizer
- add unit coverage ensuring Mermaid ids stay intact
- assert Mermaid node styles applied in e2e

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- PR_IMAGE=chat-app:issue-79-followup devspace run test-e2e

## Issue
- #79