### PR TITLE
Inline markdown diagrams without source panel

### DIFF
--- a/src/components/MarkdownDiagram.tsx
+++ b/src/components/MarkdownDiagram.tsx
@@ -15,7 +15,6 @@ import type { VisualizationSpec } from 'vega-lite';
 import { cn } from '@/lib/utils';
 import { sanitizeDiagramSvg } from '@/lib/markdown/sanitize';
 import { Alert, AlertDescription, AlertTitle } from './ui/alert';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './ui/collapsible';
 
 type DiagramLanguage = 'mermaid' | 'vega-lite';
 
@@ -227,7 +226,6 @@ export function MarkdownDiagram({ language, source, className = '' }: MarkdownDi
   const [state, setState] = useState<DiagramState>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [svgMarkup, setSvgMarkup] = useState<string | null>(null);
-  const [isSourceOpen, setIsSourceOpen] = useState(isTooLarge);
 
   const validation = useMemo(() => {
     if (language !== 'vega-lite') return { spec: undefined, error: undefined };
@@ -296,12 +294,6 @@ export function MarkdownDiagram({ language, source, className = '' }: MarkdownDi
     };
   }, [diagramId, inView, isDark, isTooLarge, language, trimmedSource, validation.error]);
 
-  useEffect(() => {
-    if (state === 'error' || state === 'blocked') {
-      setIsSourceOpen(true);
-    }
-  }, [state]);
-
   const handleVegaSvg = useCallback((svg: string) => {
     const sanitized = sanitizeSvgMarkup(svg);
     if (!sanitized) {
@@ -329,12 +321,6 @@ export function MarkdownDiagram({ language, source, className = '' }: MarkdownDi
   const showAlert = Boolean(fallbackNotice || (state === 'error' && errorMessage));
   const alertTitle = fallbackNotice ? 'Diagram too large' : `${diagramLabel} render failed`;
   const alertDescription = fallbackNotice ?? errorMessage ?? '';
-  const shouldForceSourceOpen = state !== 'ready';
-  const sourceOpen = shouldForceSourceOpen || isSourceOpen;
-  const handleSourceToggle = (open: boolean) => {
-    if (shouldForceSourceOpen) return;
-    setIsSourceOpen(open);
-  };
   const shouldRenderVega =
     language === 'vega-lite' &&
     state === 'loading' &&
@@ -378,11 +364,7 @@ export function MarkdownDiagram({ language, source, className = '' }: MarkdownDi
         </Alert>
       ) : null}
 
-      <div
-        ref={containerRef}
-        className="rounded-[12px] border border-[var(--border)] bg-[var(--background)] p-3"
-        data-state={state}
-      >
+      <div ref={containerRef} className="w-full" data-state={state}>
         {state === 'loading' || state === 'idle' ? (
           <div className="text-xs text-[var(--agyn-gray)]">Loading {diagramLabel} diagram...</div>
         ) : null}
@@ -409,23 +391,6 @@ export function MarkdownDiagram({ language, source, className = '' }: MarkdownDi
           </Suspense>
         ) : null}
       </div>
-
-      <Collapsible open={sourceOpen} onOpenChange={handleSourceToggle}>
-        <CollapsibleTrigger
-          className="self-start text-xs text-[var(--agyn-blue)] hover:text-[var(--agyn-purple)] underline"
-          type="button"
-          disabled={shouldForceSourceOpen}
-        >
-          {sourceOpen ? 'Hide source' : 'View source'}
-        </CollapsibleTrigger>
-        <CollapsibleContent className="mt-2">
-          <pre className="w-full overflow-x-auto rounded-[10px] bg-[var(--agyn-bg-light)] p-3">
-            <code className={`language-${language} block whitespace-pre-wrap font-mono text-xs text-[var(--agyn-dark)]`}>
-              {trimmedSource}
-            </code>
-          </pre>
-        </CollapsibleContent>
-      </Collapsible>
     </div>
   );
 }

--- a/src/components/MarkdownDiagram.tsx
+++ b/src/components/MarkdownDiagram.tsx
@@ -321,6 +321,7 @@ export function MarkdownDiagram({ language, source, className = '' }: MarkdownDi
   const showAlert = Boolean(fallbackNotice || (state === 'error' && errorMessage));
   const alertTitle = fallbackNotice ? 'Diagram too large' : `${diagramLabel} render failed`;
   const alertDescription = fallbackNotice ?? errorMessage ?? '';
+  const shouldShowSource = state !== 'ready';
   const shouldRenderVega =
     language === 'vega-lite' &&
     state === 'loading' &&
@@ -391,6 +392,15 @@ export function MarkdownDiagram({ language, source, className = '' }: MarkdownDi
           </Suspense>
         ) : null}
       </div>
+      {shouldShowSource ? (
+        <pre className="w-full min-w-0 max-w-full overflow-x-auto rounded-[10px] bg-[var(--agyn-bg-light)] p-3 font-mono text-sm leading-relaxed text-[var(--agyn-dark)]">
+          <code
+            className={`language-${language} block whitespace-pre-wrap font-mono text-sm leading-relaxed text-[var(--agyn-dark)]`}
+          >
+            {trimmedSource}
+          </code>
+        </pre>
+      ) : null}
     </div>
   );
 }

--- a/src/components/MarkdownDiagram.tsx
+++ b/src/components/MarkdownDiagram.tsx
@@ -393,7 +393,7 @@ export function MarkdownDiagram({ language, source, className = '' }: MarkdownDi
         ) : null}
       </div>
       {shouldShowSource ? (
-        <pre className="w-full min-w-0 max-w-full overflow-x-auto rounded-[10px] bg-[var(--agyn-bg-light)] p-3 font-mono text-sm leading-relaxed text-[var(--agyn-dark)]">
+        <pre className="w-full min-w-0 max-w-full overflow-x-auto">
           <code
             className={`language-${language} block whitespace-pre-wrap font-mono text-sm leading-relaxed text-[var(--agyn-dark)]`}
           >

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -283,10 +283,9 @@ test('blocks Vega-Lite specs with external data urls', async ({ page }) => {
   await expect(
     chart.getByText('External data URLs are not allowed. Use inline values.'),
   ).toBeVisible({ timeout: 15000 });
-  await expect(chart.locator('code')).toContainText('"url"');
 });
 
-test('shows error banner and raw code for invalid diagrams', async ({ page }) => {
+test('shows error banner for invalid diagrams', async ({ page }) => {
   const now = Date.now();
   const mermaidAnchor = `Mermaid error ${now}`;
   const vegaAnchor = `Vega error ${now}`;
@@ -310,10 +309,8 @@ test('shows error banner and raw code for invalid diagrams', async ({ page }) =>
 
   const mermaid = messageItem.getByTestId('markdown-mermaid');
   await expect(mermaid.getByText('Mermaid render failed')).toBeVisible({ timeout: 15000 });
-  await expect(mermaid.locator('code')).toContainText('graph TD');
 
   const vega = messageItem.getByTestId('markdown-vega-lite');
   await expect(vega.getByText('Vega-Lite render failed')).toBeVisible({ timeout: 15000 });
   await expect(vega.getByText('Vega-Lite spec must be valid JSON.')).toBeVisible({ timeout: 15000 });
-  await expect(vega.locator('code')).toContainText('"data"');
 });

--- a/test/e2e/inline-media.spec.ts
+++ b/test/e2e/inline-media.spec.ts
@@ -283,9 +283,10 @@ test('blocks Vega-Lite specs with external data urls', async ({ page }) => {
   await expect(
     chart.getByText('External data URLs are not allowed. Use inline values.'),
   ).toBeVisible({ timeout: 15000 });
+  await expect(chart.locator('code')).toContainText('"url"');
 });
 
-test('shows error banner for invalid diagrams', async ({ page }) => {
+test('shows error banner and raw code for invalid diagrams', async ({ page }) => {
   const now = Date.now();
   const mermaidAnchor = `Mermaid error ${now}`;
   const vegaAnchor = `Vega error ${now}`;
@@ -309,8 +310,10 @@ test('shows error banner for invalid diagrams', async ({ page }) => {
 
   const mermaid = messageItem.getByTestId('markdown-mermaid');
   await expect(mermaid.getByText('Mermaid render failed')).toBeVisible({ timeout: 15000 });
+  await expect(mermaid.locator('code')).toContainText('graph TD');
 
   const vega = messageItem.getByTestId('markdown-vega-lite');
   await expect(vega.getByText('Vega-Lite render failed')).toBeVisible({ timeout: 15000 });
   await expect(vega.getByText('Vega-Lite spec must be valid JSON.')).toBeVisible({ timeout: 15000 });
+  await expect(vega.locator('code')).toContainText('"data"');
 });


### PR DESCRIPTION
## Summary
- remove diagram source toggle and panel styling for inline rendering
- keep alerts/overflow handling for mermaid and vega diagrams
- update e2e assertions for diagram errors without source code

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- PR_IMAGE=chat-app:issue-82 devspace run-pipeline test-e2e (1 flaky: org switcher highlights current org)

Ref #82