### PR TITLE
fix(markdown): remove diagram pre framing

### DIFF
--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -263,6 +263,16 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
         return firstElement;
       }
 
+      const firstElementClassName =
+        firstElement && typeof firstElement.props?.className === 'string' ? firstElement.props.className : '';
+      const firstElementClasses = firstElementClassName.split(/\s+/).filter(Boolean);
+      const isDiagramBlock = firstElementClasses.includes('language-mermaid')
+        || firstElementClasses.includes('language-vega-lite');
+
+      if (firstElement && isDiagramBlock) {
+        return firstElement;
+      }
+
       if (firstElement && firstElement.type === 'pre') {
         return firstElement;
       }

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -98,7 +98,7 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
     if (!isInlineCode && match) {
       const language = match[1].toLowerCase();
       if (language === 'mermaid' || language === 'vega-lite') {
-        return <MarkdownDiagram language={language} source={text} />;
+        return <MarkdownDiagram language={language} source={text} className={codeClassName} />;
       }
     }
 
@@ -259,15 +259,11 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
       const childArray = Children.toArray(children);
       const firstElement = childArray.find((node): node is ReactElement => isValidElement(node));
 
-      if (firstElement && firstElement.type === MarkdownDiagram) {
-        return firstElement;
-      }
-
       const firstElementClassName =
         firstElement && typeof firstElement.props?.className === 'string' ? firstElement.props.className : '';
-      const firstElementClasses = firstElementClassName.split(/\s+/).filter(Boolean);
-      const isDiagramBlock = firstElementClasses.includes('language-mermaid')
-        || firstElementClasses.includes('language-vega-lite');
+      const languageMatch = /language-([\w-]+)/i.exec(firstElementClassName);
+      const normalizedLanguage = languageMatch?.[1].toLowerCase();
+      const isDiagramBlock = normalizedLanguage === 'mermaid' || normalizedLanguage === 'vega-lite';
 
       if (firstElement && isDiagramBlock) {
         return firstElement;

--- a/src/components/MarkdownDiagram.tsx
+++ b/src/components/MarkdownDiagram.tsx
@@ -393,7 +393,7 @@ export function MarkdownDiagram({ language, source, className = '' }: MarkdownDi
         ) : null}
       </div>
       {shouldShowSource ? (
-        <pre className="w-full min-w-0 max-w-full overflow-x-auto">
+        <pre className="w-full min-w-0 max-w-full overflow-x-auto bg-transparent p-0 rounded-none">
           <code
             className={`language-${language} block whitespace-pre-wrap font-mono text-sm leading-relaxed text-[var(--agyn-dark)]`}
           >


### PR DESCRIPTION
## Summary
- skip pre wrapper styling for mermaid/vega-lite blocks by inspecting child class names
- unframe diagram source fallback pre in MarkdownDiagram

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- VITE_API_BASE_URL=/api pnpm build
- PR_IMAGE=chat-app:issue-84 devspace run test-e2e

Closes #84