### PR TITLE
fix(chats): gate trace links for agent messages

### DIFF
--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -23,12 +23,12 @@ import type { ChatMessage as ChatMessageRecord, Chat } from '@/api/types/chat';
 import type { ChatReminder } from '@/api/types/chat-resources';
 import { cancelReminder } from '@/features/reminders/api';
 import { clearDraft, CHAT_MESSAGE_MAX_LENGTH } from '@/utils/draftStorage';
-import { resolveMessageTraceUrl } from '@/utils/tracing';
 import type { DraftParticipant } from '@/types/chats';
 import type { User } from '@/user/user-types';
 import { useChatNotifications } from '@/hooks/useChatNotifications';
 import { isDraftChatId } from './chats/draftUtils';
 import { formatDate, formatReminderDate, formatReminderScheduledTime, sanitizeSummary } from './chats/formatters';
+import { resolveChatMessageTraceUrl } from './chats/messageTracing';
 import { useChatDrafts } from './chats/useChatDrafts';
 
 const MESSAGE_LENGTH_LIMIT_LABEL = CHAT_MESSAGE_MAX_LENGTH.toLocaleString();
@@ -498,9 +498,10 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
         const senderLabel = message.senderId === currentUserId
           ? 'You'
           : resolveParticipantLabel(message.senderId, participantLookup);
+        const isAgentMessage = agentIdSet.has(message.senderId);
         const role = message.senderId === currentUserId
           ? 'user'
-          : agentIdSet.has(message.senderId)
+          : isAgentMessage
             ? 'assistant'
             : 'user';
         const content = (
@@ -511,7 +512,12 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
             ) : null}
           </div>
         );
-        const traceUrl = resolveMessageTraceUrl(config.tracingAppUrl, organizationId, message.id) ?? undefined;
+        const traceUrl = resolveChatMessageTraceUrl({
+          baseUrl: config.tracingAppUrl,
+          organizationId,
+          messageId: message.id,
+          isAgentMessage,
+        }) ?? undefined;
         return {
           id: message.id,
           role,

--- a/src/pages/chats/messageTracing.test.ts
+++ b/src/pages/chats/messageTracing.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { resolveChatMessageTraceUrl } from './messageTracing';
+
+describe('resolveChatMessageTraceUrl', () => {
+  it('returns null for agent messages', () => {
+    const url = resolveChatMessageTraceUrl({
+      baseUrl: 'https://tracing.agyn.dev',
+      organizationId: 'org-123',
+      messageId: 'msg-456',
+      isAgentMessage: true,
+    });
+
+    expect(url).toBeNull();
+  });
+
+  it('returns trace url for non-agent messages', () => {
+    const url = resolveChatMessageTraceUrl({
+      baseUrl: 'https://tracing.agyn.dev',
+      organizationId: 'org-123',
+      messageId: 'msg-456',
+      isAgentMessage: false,
+    });
+
+    expect(url).toBe('https://tracing.agyn.dev/message/msg-456?orgId=org-123');
+  });
+
+  it('returns null when trace config is missing', () => {
+    const url = resolveChatMessageTraceUrl({
+      baseUrl: null,
+      organizationId: undefined,
+      messageId: 'msg-456',
+      isAgentMessage: false,
+    });
+
+    expect(url).toBeNull();
+  });
+});

--- a/src/pages/chats/messageTracing.ts
+++ b/src/pages/chats/messageTracing.ts
@@ -1,0 +1,18 @@
+import { resolveMessageTraceUrl } from '@/utils/tracing';
+
+type MessageTraceContext = {
+  baseUrl: string | null;
+  organizationId: string | undefined;
+  messageId: string;
+  isAgentMessage: boolean;
+};
+
+export function resolveChatMessageTraceUrl({
+  baseUrl,
+  organizationId,
+  messageId,
+  isAgentMessage,
+}: MessageTraceContext): string | null {
+  if (isAgentMessage) return null;
+  return resolveMessageTraceUrl(baseUrl, organizationId, messageId);
+}


### PR DESCRIPTION
## Summary
- gate trace URL generation to non-agent messages
- add message trace helper with unit coverage

## Testing
- pnpm lint
- pnpm test

## Issue
- #73