### PR TITLE
Fix notifications subscribe rooms

### DIFF
--- a/src/api/hooks/chat-resources.ts
+++ b/src/api/hooks/chat-resources.ts
@@ -4,7 +4,7 @@ import { chatResources } from '@/api/modules/chat-resources';
 import type { ChatActivity, ChatReminder } from '@/api/types/chat-resources';
 import { UUID_REGEX } from '@/utils/validation';
 
-const DEFAULT_ACTIVITY: ChatActivity = 'idle';
+const DEFAULT_ACTIVITY: ChatActivity = 'finished';
 
 export function useChatActivity(chatId: string | undefined) {
   const queryKey = useMemo(() => ['chats', chatId, 'activity'] as const, [chatId]);

--- a/src/api/hooks/chat.ts
+++ b/src/api/hooks/chat.ts
@@ -8,6 +8,7 @@ import type {
   CreateChatResponse,
   GetChatsResponse,
   GetMessagesResponse,
+  MarkAsReadResponse,
   SendMessageResponse,
   UpdateChatResponse,
 } from '@/api/types/chat';
@@ -59,6 +60,7 @@ type SendMessageContext = {
   queryKey: (string | number)[];
   previous?: InfiniteData<GetMessagesResponse>;
   optimisticId: string;
+  previousChats?: Array<[unknown, InfiniteData<GetChatsResponse> | undefined]>;
 };
 
 export function useSendMessage() {
@@ -69,8 +71,10 @@ export function useSendMessage() {
       chatApi.sendMessage({ chatId, body, fileIds }),
     onMutate: async ({ chatId, body, senderId, fileIds }) => {
       const queryKey = ['chats', chatId, 'messages', MESSAGE_PAGE_SIZE];
+      const chatsQueryKey = ['chats', 'list'];
       await queryClient.cancelQueries({ queryKey });
       const previous = queryClient.getQueryData<InfiniteData<GetMessagesResponse>>(queryKey);
+      const previousChats = queryClient.getQueriesData<InfiniteData<GetChatsResponse>>({ queryKey: chatsQueryKey });
       const optimisticId = `optimistic-${Date.now()}`;
       const optimisticMessage: ChatMessage = {
         id: optimisticId,
@@ -96,12 +100,30 @@ export function useSendMessage() {
         return { ...current, pages: [updatedFirst, ...rest] };
       });
 
-      return { queryKey, previous, optimisticId };
+      queryClient.setQueriesData<InfiniteData<GetChatsResponse>>({ queryKey: chatsQueryKey }, (current) => {
+        if (!current) return current;
+        return {
+          ...current,
+          pages: current.pages.map((page) => ({
+            ...page,
+            chats: page.chats.map((chat) => {
+              if (chat.id !== chatId) return chat;
+              if (chat.activityStatus === 'running' || chat.activityStatus === 'pending') return chat;
+              return { ...chat, activityStatus: 'pending' };
+            }),
+          })),
+        };
+      });
+
+      return { queryKey, previous, optimisticId, previousChats };
     },
     onError: (_error, _variables, context) => {
       if (context?.previous) {
         queryClient.setQueryData(context.queryKey, context.previous);
       }
+      context?.previousChats?.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
     },
     onSuccess: (data, variables, context) => {
       const queryKey = context?.queryKey ?? ['chats', variables.chatId, 'messages', MESSAGE_PAGE_SIZE];
@@ -199,16 +221,13 @@ export function useUpdateChat() {
   });
 }
 
-export function useMarkAsRead(chatId: string | null | undefined) {
+export function useMarkAsRead() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (messageIds: string[]) =>
-      chatApi.markAsRead({ chatId: chatId as string, messageIds }),
-    onSuccess: () => {
-      if (chatId) {
-        queryClient.invalidateQueries({ queryKey: ['chats', chatId, 'messages'] });
-        queryClient.invalidateQueries({ queryKey: ['chats', 'list'] });
-      }
+    mutationFn: (request: { chatId: string }) => chatApi.markAsRead({ chatId: request.chatId }),
+    onSuccess: (_data: MarkAsReadResponse, request) => {
+      queryClient.invalidateQueries({ queryKey: ['chats', request.chatId, 'messages'] });
+      queryClient.invalidateQueries({ queryKey: ['chats', 'list'] });
     },
   });
 }

--- a/src/api/modules/chat-resources.ts
+++ b/src/api/modules/chat-resources.ts
@@ -19,8 +19,8 @@ const resolveQueue = (chatId: string) => {
 
 const resolveActivity = (chatId: string): ChatActivity => {
   const queued = queuedMessagesByChat.get(chatId) ?? [];
-  if (queued.length > 0) return 'waiting';
-  return 'idle';
+  if (queued.length > 0) return 'pending';
+  return 'finished';
 };
 
 export const chatResources = {

--- a/src/api/modules/chat.ts
+++ b/src/api/modules/chat.ts
@@ -2,6 +2,7 @@ import { connectPost } from '@/api/connect';
 import type {
   ChatMessage,
   Chat,
+  ChatActivityStatus,
   ChatStatus,
   CreateChatRequest,
   CreateChatResponse,
@@ -20,8 +21,18 @@ import type {
 const CHAT_SERVICE = '/api/agynio.api.gateway.v1.ChatGateway';
 
 type ProtoStatus = 'CHAT_STATUS_OPEN' | 'CHAT_STATUS_CLOSED';
+type ProtoActivityStatus =
+  | 'CHAT_ACTIVITY_STATUS_RUNNING'
+  | 'CHAT_ACTIVITY_STATUS_PENDING'
+  | 'CHAT_ACTIVITY_STATUS_FINISHED'
+  | 'CHAT_ACTIVITY_STATUS_UNSPECIFIED';
 
-type ChatWire = Omit<Chat, 'status'> & { status?: ChatStatus | ProtoStatus };
+type ChatWire = Omit<Chat, 'status' | 'activityStatus' | 'unreadCount' | 'activeWorkloadIds'> & {
+  status?: ChatStatus | ProtoStatus;
+  activityStatus?: ChatActivityStatus | ProtoActivityStatus | null;
+  unreadCount?: number;
+  activeWorkloadIds?: string[];
+};
 
 type UpdateChatRequestWire = Omit<UpdateChatRequest, 'status'> & { status?: ProtoStatus };
 
@@ -31,6 +42,15 @@ function protoStatusToLocal(status?: ChatStatus | ProtoStatus | null): ChatStatu
   if (status === 'CHAT_STATUS_OPEN') return 'open';
   if (status === 'open' || status === 'closed') return status;
   return 'open';
+}
+
+function protoActivityToLocal(status?: ChatActivityStatus | ProtoActivityStatus | null): ChatActivityStatus {
+  if (!status || status === 'CHAT_ACTIVITY_STATUS_UNSPECIFIED') return null;
+  if (status === 'CHAT_ACTIVITY_STATUS_RUNNING') return 'running';
+  if (status === 'CHAT_ACTIVITY_STATUS_PENDING') return 'pending';
+  if (status === 'CHAT_ACTIVITY_STATUS_FINISHED') return 'finished';
+  if (status === 'running' || status === 'pending' || status === 'finished') return status;
+  return null;
 }
 
 function localStatusToProto(status?: ChatStatus): ProtoStatus | undefined {
@@ -48,6 +68,9 @@ function normalizeChat(chat: ChatWire): Chat {
     participants: chat.participants ?? [],
     status: protoStatusToLocal(chat.status),
     summary: chat.summary ?? null,
+    activityStatus: protoActivityToLocal(chat.activityStatus),
+    unreadCount: chat.unreadCount ?? 0,
+    activeWorkloadIds: chat.activeWorkloadIds ?? [],
   };
 }
 

--- a/src/api/notifications-connect.ts
+++ b/src/api/notifications-connect.ts
@@ -16,6 +16,10 @@ type EndStreamResponse = {
   };
 };
 
+type SubscribeRequest = {
+  rooms: string[];
+};
+
 export type NotificationEnvelope = {
   event: string;
   rooms: string[];
@@ -54,6 +58,17 @@ function concatBuffers(a: Uint8Array, b: Uint8Array): Uint8Array {
   combined.set(a, 0);
   combined.set(b, a.length);
   return combined;
+}
+
+function buildSubscribePayload(rooms: readonly string[]): Uint8Array {
+  const filteredRooms = rooms
+    .map((room) => room.trim())
+    .filter((room) => room.length > 0);
+  if (filteredRooms.length === 0) {
+    throw new Error('Notifications subscribe requires at least one room');
+  }
+  const payload: SubscribeRequest = { rooms: filteredRooms };
+  return textEncoder.encode(JSON.stringify(payload));
 }
 
 function parseEndStream(data: Uint8Array): void {
@@ -98,6 +113,7 @@ export function parseMessageCreatedNotification(
 
 export async function* subscribeNotifications(
   signal: AbortSignal,
+  rooms: readonly string[],
 ): AsyncGenerator<NotificationEnvelope> {
   const token = await getAccessToken();
   const headers = new Headers({
@@ -109,7 +125,7 @@ export async function* subscribeNotifications(
     headers.set('Authorization', `Bearer ${token}`);
   }
 
-  const requestBody = createEnvelope(textEncoder.encode(JSON.stringify({})));
+  const requestBody = createEnvelope(buildSubscribePayload(rooms));
   const response = await fetch(`${config.apiBaseUrl}${SUBSCRIBE_PATH}`, {
     method: 'POST',
     headers,

--- a/src/api/notifications-connect.ts
+++ b/src/api/notifications-connect.ts
@@ -32,6 +32,10 @@ export type MessageCreatedNotification = {
   senderId: string | null;
 };
 
+export type WorkloadUpdatedNotification = {
+  workloadId: string;
+};
+
 function createEnvelope(payload: Uint8Array, flags = 0x00): Uint8Array {
   const envelope = new Uint8Array(5 + payload.length);
   envelope[0] = flags;
@@ -109,6 +113,17 @@ export function parseMessageCreatedNotification(
   const messageId = typeof payload.message_id === 'string' ? payload.message_id : null;
   const senderId = typeof payload.sender_id === 'string' ? payload.sender_id : null;
   return { threadId, messageId, senderId };
+}
+
+export function parseWorkloadUpdatedNotification(
+  envelope: NotificationEnvelope,
+): WorkloadUpdatedNotification | null {
+  if (envelope.event !== 'workload.updated') return null;
+  const payload = envelope.payload;
+  if (!payload) return null;
+  const workloadId = typeof payload.workload_id === 'string' ? payload.workload_id : null;
+  if (!workloadId) return null;
+  return { workloadId };
 }
 
 export async function* subscribeNotifications(

--- a/src/api/types/chat-resources.ts
+++ b/src/api/types/chat-resources.ts
@@ -12,4 +12,4 @@ export type ChatReminder = {
 
 export type ReminderItem = ChatReminder;
 
-export type ChatActivity = 'working' | 'waiting' | 'idle';
+export type ChatActivity = 'running' | 'pending' | 'finished';

--- a/src/api/types/chat.ts
+++ b/src/api/types/chat.ts
@@ -5,6 +5,8 @@ export type ChatParticipant = {
 
 export type ChatStatus = 'open' | 'closed';
 
+export type ChatActivityStatus = 'running' | 'pending' | 'finished' | null;
+
 export type Chat = {
   id: string;
   organizationId: string;
@@ -13,6 +15,9 @@ export type Chat = {
   updatedAt: string;
   status: ChatStatus;
   summary: string | null;
+  activityStatus: ChatActivityStatus;
+  unreadCount: number;
+  activeWorkloadIds: string[];
 };
 
 export type ChatMessage = {
@@ -43,5 +48,5 @@ export type SendMessageResponse = { message: ChatMessage };
 export type UpdateChatRequest = { chatId: string; status?: ChatStatus; summary?: string };
 export type UpdateChatResponse = { chat: Chat };
 
-export type MarkAsReadRequest = { chatId: string; messageIds: string[] };
+export type MarkAsReadRequest = { chatId: string };
 export type MarkAsReadResponse = { readCount: number };

--- a/src/components/ChatListItem.tsx
+++ b/src/components/ChatListItem.tsx
@@ -1,7 +1,7 @@
 import { formatDistanceToNow } from 'date-fns';
 import { StatusIndicator, type Status } from './StatusIndicator';
 
-export type ChatStatus = 'running' | 'pending' | 'finished' | 'failed';
+export type ChatStatus = 'running' | 'pending' | 'finished' | null;
 
 export interface ChatListItem {
   id: string;
@@ -46,6 +46,7 @@ export function ChatListItem({
     ? formatDistanceToNow(updatedAtDate, { addSuffix: true })
     : chat.updatedAt;
   const updatedAtTitle = updatedAtValid ? updatedAtDate.toLocaleString() : undefined;
+  const hasUnread = typeof chat.unreadCount === 'number' && chat.unreadCount > 0;
 
   const handleSelect = () => {
     if (onSelect) {
@@ -86,7 +87,7 @@ export function ChatListItem({
               <span className="text-xs text-[var(--agyn-gray)]" title={updatedAtTitle}>
                 {updatedAtRelative}
               </span>
-              {chat.unreadCount && chat.unreadCount > 0 ? (
+              {hasUnread ? (
                 <span className="ml-1 inline-flex items-center justify-center rounded-full bg-[var(--agyn-blue)] text-white text-[10px] px-1.5 py-0.5">
                   {chat.unreadCount}
                 </span>
@@ -108,7 +109,7 @@ export function ChatListItem({
 
           {/* Status Indicator */}
           <div className="flex-shrink-0 flex items-center gap-2">
-            <StatusIndicator status={chat.status as Status} size="sm" />
+            {chat.status ? <StatusIndicator status={chat.status as Status} size="sm" /> : null}
           </div>
         </div>
         

--- a/src/components/screens/ChatsScreen.tsx
+++ b/src/components/screens/ChatsScreen.tsx
@@ -391,7 +391,7 @@ function ChatDetailHeader({
       <div className="mb-3 flex items-start justify-between">
         <div className="flex-1">
           <div className="mb-1 flex items-center gap-2">
-            <StatusIndicator status={chat.status} size="sm" showTooltip={false} />
+            {chat.status ? <StatusIndicator status={chat.status} size="sm" showTooltip={false} /> : null}
             <span
               className="text-xs text-[var(--agyn-gray)]"
               data-testid="chat-detail-header-agent"

--- a/src/hooks/useChatNotifications.ts
+++ b/src/hooks/useChatNotifications.ts
@@ -19,7 +19,12 @@ export function useChatNotifications({
   }, [selectedChatId]);
 
   useEffect(() => {
-    if (!identityId) return;
+    const normalizedIdentityId = typeof identityId === 'string' ? identityId.trim() : '';
+    if (!normalizedIdentityId) {
+      notificationsStream.setRooms([]);
+      return;
+    }
+    notificationsStream.setRooms([`thread_participant:${normalizedIdentityId}`]);
     const offMessageCreated = notificationsStream.onMessageCreated(({ threadId }) => {
       if (selectedChatIdRef.current && selectedChatIdRef.current === threadId) {
         void queryClient.invalidateQueries({ queryKey: ['chats', threadId, 'messages'] });

--- a/src/hooks/useChatNotifications.ts
+++ b/src/hooks/useChatNotifications.ts
@@ -5,18 +5,29 @@ import { notificationsStream } from '@/lib/notifications/stream';
 type UseChatNotificationsOptions = {
   identityId: string | null | undefined;
   selectedChatId: string | null | undefined;
+  activeWorkloadIds?: string[];
+  onSelectedChatMessageCreated?: (chatId: string) => void;
 };
 
 export function useChatNotifications({
   identityId,
   selectedChatId,
+  activeWorkloadIds = [],
+  onSelectedChatMessageCreated,
 }: UseChatNotificationsOptions) {
   const queryClient = useQueryClient();
   const selectedChatIdRef = useRef<string | null>(selectedChatId ?? null);
+  const onSelectedChatMessageCreatedRef = useRef<((chatId: string) => void) | null>(
+    onSelectedChatMessageCreated ?? null,
+  );
 
   useEffect(() => {
     selectedChatIdRef.current = selectedChatId ?? null;
   }, [selectedChatId]);
+
+  useEffect(() => {
+    onSelectedChatMessageCreatedRef.current = onSelectedChatMessageCreated ?? null;
+  }, [onSelectedChatMessageCreated]);
 
   useEffect(() => {
     const normalizedIdentityId = typeof identityId === 'string' ? identityId.trim() : '';
@@ -24,11 +35,28 @@ export function useChatNotifications({
       notificationsStream.setRooms([]);
       return;
     }
-    notificationsStream.setRooms([`thread_participant:${normalizedIdentityId}`]);
+    const workloadRooms = Array.from(
+      new Set(activeWorkloadIds.map((workloadId) => workloadId.trim()).filter(Boolean)),
+    )
+      .sort()
+      .map((workloadId) => `workload:${workloadId}`);
+    notificationsStream.setRooms([`thread_participant:${normalizedIdentityId}`, ...workloadRooms]);
+  }, [identityId, activeWorkloadIds]);
+
+  useEffect(() => {
+    const normalizedIdentityId = typeof identityId === 'string' ? identityId.trim() : '';
+    if (!normalizedIdentityId) {
+      return;
+    }
     const offMessageCreated = notificationsStream.onMessageCreated(({ threadId }) => {
       if (selectedChatIdRef.current && selectedChatIdRef.current === threadId) {
+        onSelectedChatMessageCreatedRef.current?.(threadId);
         void queryClient.invalidateQueries({ queryKey: ['chats', threadId, 'messages'] });
       }
+      void queryClient.invalidateQueries({ queryKey: ['chats', 'list'] });
+    });
+
+    const offWorkloadUpdated = notificationsStream.onWorkloadUpdated(() => {
       void queryClient.invalidateQueries({ queryKey: ['chats', 'list'] });
     });
 
@@ -38,6 +66,7 @@ export function useChatNotifications({
 
     return () => {
       offMessageCreated();
+      offWorkloadUpdated();
       offReconnect();
     };
   }, [identityId, queryClient]);

--- a/src/hooks/useChatSoundNotifications.ts
+++ b/src/hooks/useChatSoundNotifications.ts
@@ -123,7 +123,13 @@ export function useChatSoundNotifications({
     const isInitialized = statusesInitializedRef.current;
     for (const chat of chats) {
       const prevStatus = previous.get(chat.id);
-      if (isInitialized && prevStatus !== undefined && chat.status === 'finished' && prevStatus !== 'finished') {
+      if (
+        isInitialized
+        && prevStatus
+        && chat.status
+        && chat.status === 'finished'
+        && prevStatus !== 'finished'
+      ) {
         controller.handleChatFinished(chat.id);
       }
       previous.set(chat.id, chat.status);

--- a/src/lib/graph/socket.ts
+++ b/src/lib/graph/socket.ts
@@ -24,7 +24,9 @@ type ChatRunSummary = {
 };
 type ServerChatCreatedPayload = { conversation: ChatSummary };
 type ServerChatUpdatedPayload = { conversation: ChatSummary };
-type ServerChatActivityPayload = { conversationId: string; activity: 'working' | 'waiting' | 'idle' };
+type ServerChatActivity = 'running' | 'pending' | 'finished' | 'working' | 'waiting' | 'idle';
+type ChatActivity = 'running' | 'pending' | 'finished';
+type ServerChatActivityPayload = { conversationId: string; activity: ServerChatActivity };
 type ServerChatRemindersPayload = { conversationId: string; remindersCount: number };
 type ServerMessageCreatedPayload = { conversationId: string; message: MessageSummary };
 type ServerRunStatusChangedPayload = { conversationId: string; run: ServerRunSummary };
@@ -48,12 +50,19 @@ type StateListener = (ev: { nodeId: string; state: Record<string, unknown>; upda
 type ReminderListener = (ev: ReminderCountEvent) => void;
 type ChatCreatedPayload = { chat: ChatSummary };
 type ChatUpdatedPayload = { chat: ChatSummary };
-type ChatActivityPayload = { chatId: string; activity: 'working' | 'waiting' | 'idle' };
+type ChatActivityPayload = { chatId: string; activity: ChatActivity };
 type ChatRemindersPayload = { chatId: string; remindersCount: number };
 type ChatMessageCreatedPayload = { message: MessageSummary; chatId: string };
 type ChatRunStatusChangedPayload = { chatId: string; run: ChatRunSummary };
 
 const socketsEnabled = getSocketsEnabled();
+
+const normalizeChatActivity = (activity: ServerChatActivity): ChatActivity => {
+  if (activity === 'working') return 'running';
+  if (activity === 'waiting') return 'pending';
+  if (activity === 'idle') return 'finished';
+  return activity;
+};
 
 class GraphSocket {
   // Typed socket instance; null until connected
@@ -179,7 +188,10 @@ class GraphSocket {
     this.socketCleanup.push(() => socket.off('conversation_updated', handleChatUpdated));
 
     const handleChatActivityChanged: ServerToClientEvents['conversation_activity_changed'] = (payload) => {
-      const chatPayload: ChatActivityPayload = { chatId: payload.conversationId, activity: payload.activity };
+      const chatPayload: ChatActivityPayload = {
+        chatId: payload.conversationId,
+        activity: normalizeChatActivity(payload.activity),
+      };
       for (const fn of this.chatActivityListeners) fn(chatPayload);
     };
     socket.on('conversation_activity_changed', handleChatActivityChanged);

--- a/src/lib/notifications/stream.test.ts
+++ b/src/lib/notifications/stream.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NotificationEnvelope } from '@/api/notifications-connect';
+
+const subscribeNotificationsMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/api/notifications-connect', () => ({
+  parseMessageCreatedNotification: () => null,
+  subscribeNotifications: subscribeNotificationsMock,
+}));
+
+import { notificationsStream } from './stream';
+
+const waitForAbort = (signal: AbortSignal) =>
+  new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+
+const createIdleStream = (signal: AbortSignal) =>
+  (async function* (): AsyncGenerator<NotificationEnvelope> {
+    await waitForAbort(signal);
+    yield* [] as NotificationEnvelope[];
+  })();
+
+describe('notificationsStream', () => {
+  beforeEach(() => {
+    subscribeNotificationsMock.mockImplementation((signal: AbortSignal, _rooms: readonly string[]) =>
+      createIdleStream(signal),
+    );
+  });
+
+  afterEach(() => {
+    notificationsStream.setRooms([]);
+    subscribeNotificationsMock.mockReset();
+  });
+
+  it('subscribes once rooms are provided', () => {
+    const off = notificationsStream.onEnvelope(() => {});
+
+    notificationsStream.setRooms(['thread_participant:abc']);
+
+    expect(subscribeNotificationsMock).toHaveBeenCalledTimes(1);
+    expect(subscribeNotificationsMock.mock.calls[0]?.[1]).toEqual(['thread_participant:abc']);
+
+    off();
+    notificationsStream.setRooms([]);
+  });
+
+  it('restarts the stream when rooms change', () => {
+    const off = notificationsStream.onEnvelope(() => {});
+
+    notificationsStream.setRooms(['thread_participant:abc']);
+
+    expect(subscribeNotificationsMock).toHaveBeenCalledTimes(1);
+    const firstSignal = subscribeNotificationsMock.mock.calls[0]?.[0] as AbortSignal;
+
+    notificationsStream.setRooms(['thread_participant:def']);
+
+    expect(subscribeNotificationsMock).toHaveBeenCalledTimes(2);
+    const secondSignal = subscribeNotificationsMock.mock.calls[1]?.[0] as AbortSignal;
+    expect(firstSignal.aborted).toBe(true);
+    expect(secondSignal).not.toBe(firstSignal);
+
+    off();
+    notificationsStream.setRooms([]);
+  });
+});

--- a/src/lib/notifications/stream.test.ts
+++ b/src/lib/notifications/stream.test.ts
@@ -10,6 +10,8 @@ vi.mock('@/api/notifications-connect', () => ({
 
 import { notificationsStream } from './stream';
 
+const RECONNECT_DELAY_MS = 3000;
+
 const waitForAbort = (signal: AbortSignal) =>
   new Promise<void>((resolve) => {
     if (signal.aborted) {
@@ -25,6 +27,31 @@ const createIdleStream = (signal: AbortSignal) =>
     yield* [] as NotificationEnvelope[];
   })();
 
+const waitForSignalOrDone = async (signal: AbortSignal, done: Promise<void>) => {
+  await Promise.race([waitForAbort(signal), done]);
+};
+
+const createControlledStream = (signal: AbortSignal, done: Promise<void>) =>
+  (async function* (): AsyncGenerator<NotificationEnvelope> {
+    await waitForSignalOrDone(signal, done);
+    yield* [] as NotificationEnvelope[];
+  })();
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createDeferred = <T,>() => {
+  let resolve: (value: T | PromiseLike<T>) => void;
+  let reject: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolver, rejecter) => {
+    resolve = resolver;
+    reject = rejecter;
+  });
+  return { promise, resolve: resolve!, reject: reject! };
+};
+
 describe('notificationsStream', () => {
   beforeEach(() => {
     subscribeNotificationsMock.mockImplementation((signal: AbortSignal, _rooms: readonly string[]) =>
@@ -33,6 +60,7 @@ describe('notificationsStream', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     notificationsStream.setRooms([]);
     subscribeNotificationsMock.mockReset();
   });
@@ -63,6 +91,36 @@ describe('notificationsStream', () => {
     const secondSignal = subscribeNotificationsMock.mock.calls[1]?.[0] as AbortSignal;
     expect(firstSignal.aborted).toBe(true);
     expect(secondSignal).not.toBe(firstSignal);
+
+    off();
+    notificationsStream.setRooms([]);
+  });
+
+  it('does not resubscribe twice when rooms change during reconnect delay', async () => {
+    vi.useFakeTimers();
+    const done = createDeferred<void>();
+    subscribeNotificationsMock
+      .mockImplementationOnce((signal: AbortSignal, _rooms: readonly string[]) =>
+        createControlledStream(signal, done.promise),
+      )
+      .mockImplementation((signal: AbortSignal, _rooms: readonly string[]) => createIdleStream(signal));
+
+    const off = notificationsStream.onEnvelope(() => {});
+
+    notificationsStream.setRooms(['thread_participant:abc']);
+
+    expect(subscribeNotificationsMock).toHaveBeenCalledTimes(1);
+
+    done.resolve();
+    await flushPromises();
+
+    notificationsStream.setRooms(['thread_participant:def']);
+
+    expect(subscribeNotificationsMock).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(RECONNECT_DELAY_MS);
+
+    expect(subscribeNotificationsMock).toHaveBeenCalledTimes(2);
 
     off();
     notificationsStream.setRooms([]);

--- a/src/lib/notifications/stream.test.ts
+++ b/src/lib/notifications/stream.test.ts
@@ -5,6 +5,7 @@ const subscribeNotificationsMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/api/notifications-connect', () => ({
   parseMessageCreatedNotification: () => null,
+  parseWorkloadUpdatedNotification: () => null,
   subscribeNotifications: subscribeNotificationsMock,
 }));
 

--- a/src/lib/notifications/stream.ts
+++ b/src/lib/notifications/stream.ts
@@ -1,8 +1,10 @@
 import {
   parseMessageCreatedNotification,
+  parseWorkloadUpdatedNotification,
   subscribeNotifications,
   type MessageCreatedNotification,
   type NotificationEnvelope,
+  type WorkloadUpdatedNotification,
 } from '@/api/notifications-connect';
 
 const RECONNECT_DELAY_MS = 3000;
@@ -10,6 +12,7 @@ const RECONNECT_DELAY_MS = 3000;
 type EnvelopeListener = (envelope: NotificationEnvelope) => void;
 type ReconnectListener = () => void;
 type MessageCreatedListener = (notification: MessageCreatedNotification) => void;
+type WorkloadUpdatedListener = (notification: WorkloadUpdatedNotification) => void;
 
 const normalizeRooms = (rooms: readonly string[]): string[] => {
   const uniqueRooms = new Set<string>();
@@ -44,6 +47,15 @@ class NotificationsStream {
   onMessageCreated(cb: MessageCreatedListener): () => void {
     const handler = (envelope: NotificationEnvelope) => {
       const parsed = parseMessageCreatedNotification(envelope);
+      if (!parsed) return;
+      cb(parsed);
+    };
+    return this.onEnvelope(handler);
+  }
+
+  onWorkloadUpdated(cb: WorkloadUpdatedListener): () => void {
+    const handler = (envelope: NotificationEnvelope) => {
+      const parsed = parseWorkloadUpdatedNotification(envelope);
       if (!parsed) return;
       cb(parsed);
     };

--- a/src/lib/notifications/stream.ts
+++ b/src/lib/notifications/stream.ts
@@ -30,6 +30,7 @@ class NotificationsStream {
   private hasConnected = false;
   private rooms: string[] = [];
   private roomsKey = serializeRooms([]);
+  private reconnectTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
 
   onEnvelope(cb: EnvelopeListener): () => void {
     this.listeners.add(cb);
@@ -92,6 +93,7 @@ class NotificationsStream {
   }
 
   private disconnect({ resetConnectionState = true }: { resetConnectionState?: boolean } = {}) {
+    this.clearReconnectTimer();
     this.abortController?.abort();
     this.abortController = null;
     if (resetConnectionState) {
@@ -103,6 +105,12 @@ class NotificationsStream {
     if (!this.abortController) return;
     this.disconnect({ resetConnectionState: false });
     this.ensureConnected();
+  }
+
+  private clearReconnectTimer() {
+    if (this.reconnectTimer === null) return;
+    globalThis.clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
   }
 
   private emitEnvelope(envelope: NotificationEnvelope) {
@@ -119,8 +127,13 @@ class NotificationsStream {
 
   private scheduleReconnect() {
     if (this.listeners.size === 0 && this.reconnectListeners.size === 0) return;
-    globalThis.setTimeout(() => {
-      if (this.abortController?.signal.aborted) return;
+    const controller = this.abortController;
+    if (!controller) return;
+    this.clearReconnectTimer();
+    this.reconnectTimer = globalThis.setTimeout(() => {
+      if (this.abortController !== controller) return;
+      if (controller.signal.aborted) return;
+      this.reconnectTimer = null;
       void this.startStream();
     }, RECONNECT_DELAY_MS);
   }

--- a/src/lib/notifications/stream.ts
+++ b/src/lib/notifications/stream.ts
@@ -11,11 +11,25 @@ type EnvelopeListener = (envelope: NotificationEnvelope) => void;
 type ReconnectListener = () => void;
 type MessageCreatedListener = (notification: MessageCreatedNotification) => void;
 
+const normalizeRooms = (rooms: readonly string[]): string[] => {
+  const uniqueRooms = new Set<string>();
+  for (const room of rooms) {
+    const trimmed = room.trim();
+    if (!trimmed) continue;
+    uniqueRooms.add(trimmed);
+  }
+  return Array.from(uniqueRooms).sort();
+};
+
+const serializeRooms = (rooms: readonly string[]): string => JSON.stringify(rooms);
+
 class NotificationsStream {
   private abortController: AbortController | null = null;
   private listeners = new Set<EnvelopeListener>();
   private reconnectListeners = new Set<ReconnectListener>();
   private hasConnected = false;
+  private rooms: string[] = [];
+  private roomsKey = serializeRooms([]);
 
   onEnvelope(cb: EnvelopeListener): () => void {
     this.listeners.add(cb);
@@ -44,10 +58,31 @@ class NotificationsStream {
     };
   }
 
+  setRooms(rooms: readonly string[]) {
+    const normalizedRooms = normalizeRooms(rooms);
+    const nextKey = serializeRooms(normalizedRooms);
+    if (nextKey === this.roomsKey) return;
+    this.rooms = normalizedRooms;
+    this.roomsKey = nextKey;
+
+    if (this.rooms.length === 0) {
+      this.disconnect();
+      return;
+    }
+
+    if (this.abortController) {
+      this.restartStream();
+      return;
+    }
+
+    this.ensureConnected();
+  }
+
   private ensureConnected() {
     if (this.abortController) return;
+    if (this.rooms.length === 0) return;
+    if (this.listeners.size === 0 && this.reconnectListeners.size === 0) return;
     this.abortController = new AbortController();
-    this.hasConnected = false;
     void this.startStream();
   }
 
@@ -56,10 +91,18 @@ class NotificationsStream {
     this.disconnect();
   }
 
-  private disconnect() {
+  private disconnect({ resetConnectionState = true }: { resetConnectionState?: boolean } = {}) {
     this.abortController?.abort();
     this.abortController = null;
-    this.hasConnected = false;
+    if (resetConnectionState) {
+      this.hasConnected = false;
+    }
+  }
+
+  private restartStream() {
+    if (!this.abortController) return;
+    this.disconnect({ resetConnectionState: false });
+    this.ensureConnected();
   }
 
   private emitEnvelope(envelope: NotificationEnvelope) {
@@ -85,12 +128,13 @@ class NotificationsStream {
   private async startStream() {
     const signal = this.abortController?.signal;
     if (!signal) return;
+    const rooms = [...this.rooms];
     const isReconnect = this.hasConnected;
     this.hasConnected = true;
     if (isReconnect) this.emitReconnect();
 
     try {
-      for await (const envelope of subscribeNotifications(signal)) {
+      for await (const envelope of subscribeNotifications(signal, rooms)) {
         this.emitEnvelope(envelope);
       }
       if (signal.aborted) return;

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -217,9 +217,16 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
     return items.filter((chat) => !chat.organizationId || chat.organizationId === organizationId);
   }, [chatsQuery.data, organizationId]);
 
+  const visibleChatSummaries = useMemo(() => {
+    if (filterMode === 'all') return chatSummaries;
+    const isOpen = (chat: Chat) => chat.status === 'open';
+    if (filterMode === 'open') return chatSummaries.filter(isOpen);
+    return chatSummaries.filter((chat) => !isOpen(chat));
+  }, [chatSummaries, filterMode]);
+
   const activeWorkloadIds = useMemo(() => {
     const ids = new Set<string>();
-    for (const chat of chatSummaries) {
+    for (const chat of visibleChatSummaries) {
       for (const workloadId of chat.activeWorkloadIds) {
         const normalized = workloadId.trim();
         if (normalized) {
@@ -228,7 +235,7 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
       }
     }
     return [...ids];
-  }, [chatSummaries]);
+  }, [visibleChatSummaries]);
 
   const userParticipantIds = useMemo(() => {
     const ids = new Set<string>();

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -180,11 +180,6 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
   const canUpdateChat = Boolean(selectedChatId && !effectiveDraftMode);
   const isThreadDegraded = Boolean(selectedChatId && !effectiveDraftMode && degradedChatIds.has(selectedChatId));
 
-  useChatNotifications({
-    identityId: currentUserId,
-    selectedChatId: effectiveDraftMode ? null : selectedChatId ?? null,
-  });
-
   useEffect(() => {
     clearAttachments();
   }, [clearAttachments, selectedChatId]);
@@ -221,6 +216,19 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
     if (!organizationId) return [];
     return items.filter((chat) => !chat.organizationId || chat.organizationId === organizationId);
   }, [chatsQuery.data, organizationId]);
+
+  const activeWorkloadIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const chat of chatSummaries) {
+      for (const workloadId of chat.activeWorkloadIds) {
+        const normalized = workloadId.trim();
+        if (normalized) {
+          ids.add(normalized);
+        }
+      }
+    }
+    return [...ids];
+  }, [chatSummaries]);
 
   const userParticipantIds = useMemo(() => {
     const ids = new Set<string>();
@@ -317,7 +325,7 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
         subtitle: DRAFT_SUMMARY_LABEL,
         createdAt: draft.createdAt,
         updatedAt: draft.createdAt,
-        status: 'pending',
+        status: null,
         isOpen: true,
         unreadCount: 0,
       };
@@ -334,9 +342,9 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
         subtitle: resolveChatSummary(chat.summary),
         createdAt: chat.createdAt,
         updatedAt: chat.updatedAt,
-        status: 'pending',
+        status: chat.activityStatus,
         isOpen: chat.status === 'open',
-        unreadCount: 0,
+        unreadCount: chat.unreadCount,
       } satisfies ChatListItem;
     });
     return [...fromDrafts, ...fromData];
@@ -352,7 +360,7 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
       subtitle: undefined,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
-      status: 'pending',
+      status: null,
       isOpen: true,
       unreadCount: 0,
     } satisfies ChatListItem;
@@ -382,9 +390,30 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
     refetchOnWindowFocus: false,
   });
 
-  const markAsRead = useMarkAsRead(
-    effectiveDraftMode ? null : selectedChatId,
+  const markAsRead = useMarkAsRead();
+
+  const triggerMarkAsRead = useCallback(
+    (chatId: string) => {
+      const normalized = chatId.trim();
+      if (!normalized) return;
+      markAsRead.mutate(
+        { chatId: normalized },
+        {
+          onError: (error) => {
+            notifyError(error instanceof Error ? error.message : 'Failed to mark messages as read.');
+          },
+        },
+      );
+    },
+    [markAsRead],
   );
+
+  useChatNotifications({
+    identityId: currentUserId,
+    selectedChatId: effectiveDraftMode ? null : selectedChatId ?? null,
+    activeWorkloadIds,
+    onSelectedChatMessageCreated: triggerMarkAsRead,
+  });
 
   const sendMessage = useSendMessage();
   const createChat = useCreateChat(organizationId);
@@ -459,22 +488,17 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
     container.scrollTop = container.scrollHeight;
   }, [selectedChatId]);
 
-  const unreadMessageIdsRef = useRef<string | null>(null);
+  const lastReadChatIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!selectedChatId || effectiveDraftMode) return;
-    if (unreadMessageIds.length === 0) return;
-    if (markAsRead.isPending) return;
-    const key = `${selectedChatId}:${unreadMessageIds.join(',')}`;
-    if (unreadMessageIdsRef.current === key) return;
-    unreadMessageIdsRef.current = key;
-    markAsRead.mutate(unreadMessageIds, {
-      onError: (error) => {
-        unreadMessageIdsRef.current = null;
-        notifyError(error instanceof Error ? error.message : 'Failed to mark messages as read.');
-      },
-    });
-  }, [selectedChatId, effectiveDraftMode, unreadMessageIds, markAsRead]);
+    if (!selectedChatId || effectiveDraftMode) {
+      lastReadChatIdRef.current = null;
+      return;
+    }
+    if (lastReadChatIdRef.current === selectedChatId) return;
+    lastReadChatIdRef.current = selectedChatId;
+    triggerMarkAsRead(selectedChatId);
+  }, [selectedChatId, effectiveDraftMode, triggerMarkAsRead]);
 
   const unreadMessageIdSet = useMemo(() => new Set(unreadMessageIds), [unreadMessageIds]);
 


### PR DESCRIPTION
## Summary
- send rooms in the notifications subscribe payload (thread_participant)
- track room lists in the notifications stream and restart when they change
- add stream tests for room-driven resubscribe behavior

## Room list derivation
Rooms are derived from the current identity id as `thread_participant:{identityId}` and normalized
(deduplicated/sorted). The stream restarts when the normalized room list changes.

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- VITE_API_BASE_URL=/api pnpm build

Refs https://github.com/agynio/architecture/issues/142 (#142)