### PR TITLE
fix(markdown): unwrap diagram pre blocks

### DIFF
--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -94,14 +94,6 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
   const renderCode = ({ inline, className: codeClassName, children, style, node, ...props }: MarkdownCodeProps) => {
     const { match, isInlineCode } = getCodeRenderMeta({ inline, className: codeClassName, node });
     const text = String(children).replace(/\n$/, '');
-
-    if (!isInlineCode && match) {
-      const language = match[1].toLowerCase();
-      if (language === 'mermaid' || language === 'vega-lite') {
-        return <MarkdownDiagram language={language} source={text} />;
-      }
-    }
-
     if (!isInlineCode) {
       return (
         <code
@@ -258,6 +250,21 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
     pre: ({ children, className: preClassName, style: preStyle, node: _node, ...props }: MarkdownPreProps) => {
       const childArray = Children.toArray(children);
       const firstElement = childArray.find((node): node is ReactElement => isValidElement(node));
+
+      // Special-case diagram code blocks so they are rendered without the normal
+      // markdown <pre> framing. This keeps the rest of markdown behavior unchanged.
+      if (
+        firstElement &&
+        firstElement.type === 'code' &&
+        typeof firstElement.props.className === 'string'
+      ) {
+        const match = /language-([\w-]+)/.exec(firstElement.props.className);
+        const language = match?.[1]?.toLowerCase();
+        if (language === 'mermaid' || language === 'vega-lite') {
+          const text = String(firstElement.props.children ?? '').replace(/\n$/, '');
+          return <MarkdownDiagram language={language} source={text} />;
+        }
+      }
 
       if (firstElement && firstElement.type === MarkdownDiagram) {
         return firstElement;

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -98,7 +98,7 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
     if (!isInlineCode && match) {
       const language = match[1].toLowerCase();
       if (language === 'mermaid' || language === 'vega-lite') {
-        return <MarkdownDiagram language={language} source={text} className={codeClassName} />;
+        return <MarkdownDiagram language={language} source={text} />;
       }
     }
 
@@ -259,13 +259,7 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
       const childArray = Children.toArray(children);
       const firstElement = childArray.find((node): node is ReactElement => isValidElement(node));
 
-      const firstElementClassName =
-        firstElement && typeof firstElement.props?.className === 'string' ? firstElement.props.className : '';
-      const languageMatch = /language-([\w-]+)/i.exec(firstElementClassName);
-      const normalizedLanguage = languageMatch?.[1].toLowerCase();
-      const isDiagramBlock = normalizedLanguage === 'mermaid' || normalizedLanguage === 'vega-lite';
-
-      if (firstElement && isDiagramBlock) {
+      if (firstElement && firstElement.type === MarkdownDiagram) {
         return firstElement;
       }
 

--- a/src/components/MarkdownDiagram.tsx
+++ b/src/components/MarkdownDiagram.tsx
@@ -393,7 +393,7 @@ export function MarkdownDiagram({ language, source, className = '' }: MarkdownDi
         ) : null}
       </div>
       {shouldShowSource ? (
-        <pre className="w-full min-w-0 max-w-full overflow-x-auto bg-transparent p-0 rounded-none">
+        <pre className="w-full min-w-0 max-w-full overflow-x-auto">
           <code
             className={`language-${language} block whitespace-pre-wrap font-mono text-sm leading-relaxed text-[var(--agyn-dark)]`}
           >


### PR DESCRIPTION
Restores #85 behavior: render mermaid/vega-lite fenced blocks without normal markdown <pre> framing while leaving all other markdown code/inline code paths unchanged.

Implementation:
- In MarkdownContent pre renderer: detect pre > code.language-mermaid|language-vega-lite and render MarkdownDiagram directly.
- Remove diagram handling from code renderer to avoid block/inline regressions.