### PR TITLE
fix(markdown): restore inline code and heading styles

### DIFF
--- a/src/components/MarkdownContent.test.tsx
+++ b/src/components/MarkdownContent.test.tsx
@@ -33,4 +33,25 @@ describe('MarkdownContent', () => {
     const [props] = mediaImageSpy.mock.calls[0] as [{ src?: string }];
     expect(props.src).toBe(url);
   });
+
+  it('renders inline code with inline-safe classes', async () => {
+    const { MarkdownContent } = await import('./MarkdownContent');
+
+    const markup = renderToStaticMarkup(<MarkdownContent content={"before `test` after"} />);
+
+    expect(markup).toContain('<code class="inline rounded');
+    expect(markup).toContain('font-mono');
+    expect(markup).toContain('text-[var(--agyn-purple)]');
+    expect(markup).not.toContain('<code class="block whitespace-pre-wrap');
+  });
+
+  it('renders headings with explicit typography classes', async () => {
+    const { MarkdownContent } = await import('./MarkdownContent');
+
+    const markup = renderToStaticMarkup(<MarkdownContent content={"# Header"} />);
+
+    expect(markup).toContain('<h1 class="mb-4 mt-6 text-3xl font-bold');
+    expect(markup).toContain('Header</h1>');
+  });
+
 });

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -21,7 +21,12 @@ interface MarkdownContentProps {
 
 type MarkdownCodeProps = ComponentPropsWithoutRef<'code'> & {
   inline?: boolean;
-  node?: { type?: string } | null;
+  node?: {
+    type?: string;
+    tagName?: string;
+    position?: unknown;
+    properties?: { className?: string | string[] };
+  } | null;
 };
 
 type MarkdownPreProps = ComponentPropsWithoutRef<'pre'> & {
@@ -58,8 +63,8 @@ type MarkdownListItemProps = ComponentPropsWithoutRef<'li'> & ReactMarkdownListI
 
 const getCodeRenderMeta = ({ inline, className, node }: Pick<MarkdownCodeProps, 'inline' | 'className' | 'node'>) => {
   const match = /language-([\w-]+)/.exec(className || '');
-  const nodeType = typeof node === 'object' && node ? (node as { type?: string }).type : undefined;
-  const isInlineCode = nodeType ? nodeType === 'inlineCode' : inline ?? !match;
+  const nodeType = typeof node === 'object' && node ? node.type : undefined;
+  const isInlineCode = nodeType === 'inlineCode' || inline === true || (inline !== false && !match);
   return { match, isInlineCode } as const;
 };
 
@@ -113,8 +118,8 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
 
     return (
       <code
-        className="bg-[var(--agyn-bg-light)] text-[var(--agyn-purple)] px-1.5 py-0.5 rounded text-sm break-words max-w-full whitespace-pre-wrap"
-        style={{ overflowWrap: 'break-word', wordBreak: 'break-word', ...style }}
+        className="inline rounded bg-[var(--agyn-bg-light)] px-1.5 py-0.5 font-mono text-[0.875em] leading-normal text-[var(--agyn-purple)] break-words"
+        style={{ overflowWrap: 'anywhere', ...style }}
         {...props}
       >
         {children}
@@ -166,32 +171,32 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
   const markdownComponents: Components = {
     // Headings
     h1: ({ children }) => (
-      <h1 className="text-[var(--agyn-dark)] mb-4 mt-6 first:mt-0">
+      <h1 className="mb-4 mt-6 text-3xl font-bold leading-tight tracking-tight text-[var(--agyn-dark)] first:mt-0">
         {children}
       </h1>
     ),
     h2: ({ children }) => (
-      <h2 className="text-[var(--agyn-dark)] mb-3 mt-5 first:mt-0">
+      <h2 className="mb-3 mt-5 text-2xl font-semibold leading-tight text-[var(--agyn-dark)] first:mt-0">
         {children}
       </h2>
     ),
     h3: ({ children }) => (
-      <h3 className="text-[var(--agyn-dark)] mb-2 mt-4 first:mt-0">
+      <h3 className="mb-2 mt-4 text-xl font-semibold leading-snug text-[var(--agyn-dark)] first:mt-0">
         {children}
       </h3>
     ),
     h4: ({ children }) => (
-      <h4 className="text-[var(--agyn-dark)] mb-2 mt-3 first:mt-0">
+      <h4 className="mb-2 mt-3 text-base font-semibold leading-snug text-[var(--agyn-dark)] first:mt-0">
         {children}
       </h4>
     ),
     h5: ({ children }) => (
-      <h5 className="text-[var(--agyn-dark)] mb-2 mt-3 first:mt-0">
+      <h5 className="mb-2 mt-3 text-sm font-semibold leading-snug text-[var(--agyn-dark)] first:mt-0">
         {children}
       </h5>
     ),
     h6: ({ children }) => (
-      <h6 className="text-[var(--agyn-dark)] mb-2 mt-3 first:mt-0">
+      <h6 className="mb-2 mt-3 text-xs font-semibold uppercase leading-snug tracking-wide text-[var(--agyn-gray)] first:mt-0">
         {children}
       </h6>
     ),
@@ -296,9 +301,10 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
               return node;
             }
 
+            const languageClassName = /(?:^|\s)(language-[\w-]+)(?:\s|$)/.exec(node.props.className ?? '')?.[1];
             const mergedChildClassName = [
               'block whitespace-pre-wrap font-mono text-sm leading-relaxed text-[var(--agyn-dark)]',
-              node.props.className,
+              languageClassName,
             ]
               .filter(Boolean)
               .join(' ');


### PR DESCRIPTION
## Summary
- Detect backtick inline code without relying on the removed/unstable react-markdown inline prop so it renders as inline instead of block code
- Preserve block code styling by stripping only conflicting inline classes when wrapping code in pre
- Add explicit heading typography classes so markdown headings have size/weight styles instead of only color/margins
- Add regression tests for inline code and h1 rendering

## Root cause
react-markdown v9 does not reliably pass the old inline metadata to custom code renderers. Inline code without a language class was falling through to the block-code renderer and receiving block whitespace classes. Heading renderers also added text-* color classes, which meant the base typography selectors did not apply while no replacement size/weight classes were present.

## Test plan
- ./node_modules/.bin/vitest run src/components/MarkdownContent.test.tsx --reporter=verbose
- ./node_modules/.bin/eslint .
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vite build