### PR TITLE
Fix app message sender labels

### DIFF
--- a/src/api/hooks/apps.ts
+++ b/src/api/hooks/apps.ts
@@ -1,0 +1,24 @@
+import { useQueries } from '@tanstack/react-query';
+import { appsApi } from '@/api/modules/apps';
+import type { AppProfile } from '@/api/types/apps';
+
+export function useAppProfiles(identityIds: string[]) {
+  const sortedIds = [...new Set(identityIds.map((id) => id.trim()).filter(Boolean))].sort();
+  const queries = useQueries({
+    queries: sortedIds.map((identityId) => ({
+      queryKey: ['apps', 'profile', identityId],
+      queryFn: () => appsApi.getAppProfile({ identityId }),
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
+      retry: false,
+    })),
+  });
+
+  return sortedIds.reduce((profiles, identityId, index) => {
+    const profile = queries[index]?.data?.profile;
+    if (profile) {
+      profiles.set(identityId, profile);
+    }
+    return profiles;
+  }, new Map<string, AppProfile>());
+}

--- a/src/api/modules/apps.ts
+++ b/src/api/modules/apps.ts
@@ -1,0 +1,15 @@
+import { connectPost } from '@/api/connect';
+import type { GetAppProfileRequest, GetAppProfileResponse } from '@/api/types/apps';
+
+const APPS_GATEWAY = '/api/agynio.api.gateway.v1.AppsGateway';
+
+export const appsApi = {
+  getAppProfile: async (req: GetAppProfileRequest): Promise<GetAppProfileResponse> => {
+    const resp = await connectPost<GetAppProfileRequest, GetAppProfileResponse>(
+      APPS_GATEWAY,
+      'GetAppProfile',
+      req,
+    );
+    return { profile: resp.profile };
+  },
+};

--- a/src/api/types/apps.ts
+++ b/src/api/types/apps.ts
@@ -1,0 +1,10 @@
+export type AppProfile = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  icon: string;
+};
+
+export type GetAppProfileRequest = { identityId: string };
+export type GetAppProfileResponse = { profile: AppProfile };

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -14,6 +14,7 @@ import { useFileAttachments } from '@/hooks/useFileAttachments';
 import { config } from '@/config';
 import { useAgentsList } from '@/api/hooks/agents';
 import { useBatchGetUsers } from '@/api/hooks/users';
+import { useAppProfiles } from '@/api/hooks/apps';
 import { useChats, useChatMessages, useCreateChat, useSendMessage, useMarkAsRead, useUpdateChat } from '@/api/hooks/chat';
 import {
   useChatReminders,
@@ -447,6 +448,44 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
     [chatMessages, deletedMessageIds],
   );
 
+  const appIdentityIds = useMemo(() => {
+    const participantIds = new Set<string>();
+    const fetchedUserIds = new Set((batchUsersQuery.data?.users ?? []).map((fetchedUser) => fetchedUser.meta.id));
+    const ids = new Set<string>();
+
+    for (const chat of chatSummaries) {
+      for (const participant of chat.participants) {
+        participantIds.add(participant.id);
+        if (
+          batchUsersQuery.isFetched &&
+          participant.id !== currentUserId &&
+          !agentIdSet.has(participant.id) &&
+          !fetchedUserIds.has(participant.id)
+        ) {
+          ids.add(participant.id);
+        }
+      }
+    }
+
+    for (const message of filteredChatMessages) {
+      if (!participantIds.has(message.senderId)) {
+        ids.add(message.senderId);
+      }
+    }
+
+    return [...ids];
+  }, [agentIdSet, batchUsersQuery.data, batchUsersQuery.isFetched, chatSummaries, currentUserId, filteredChatMessages]);
+
+  const appProfiles = useAppProfiles(appIdentityIds);
+
+  const senderLookup = useMemo(() => {
+    const map = new Map(participantLookup);
+    for (const [identityId, profile] of appProfiles) {
+      map.set(identityId, { id: identityId, name: profile.name || profile.slug || identityId, type: 'app' });
+    }
+    return map;
+  }, [appProfiles, participantLookup]);
+
   const unreadCount = chatMessagesQuery.data?.pages?.[0]?.unreadCount ?? 0;
   const unreadMessageIds = useMemo(() => {
     if (!unreadCount) return [] as string[];
@@ -528,7 +567,7 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
       filteredChatMessages.map((message) => {
         const senderLabel = message.senderId === currentUserId
           ? 'You'
-          : resolveParticipantLabel(message.senderId, participantLookup);
+          : resolveParticipantLabel(message.senderId, senderLookup);
         const isAgentMessage = agentIdSet.has(message.senderId);
         const role = message.senderId === currentUserId
           ? 'user'
@@ -561,7 +600,7 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
           traceUrl,
         } satisfies ChatMessage;
       }),
-    [filteredChatMessages, currentUserId, participantLookup, agentIdSet, unreadMessageIdSet, handleDeleteMessage, organizationId],
+    [filteredChatMessages, currentUserId, senderLookup, agentIdSet, unreadMessageIdSet, handleDeleteMessage, organizationId],
   );
 
   const chatRuns = useMemo<ChatRun[]>(() => {

--- a/src/types/chats.ts
+++ b/src/types/chats.ts
@@ -1,7 +1,7 @@
 export type DraftParticipant = {
   id: string;
   name: string;
-  type: 'agent' | 'user';
+  type: 'agent' | 'user' | 'app';
 };
 
 export type ChatDraft = {


### PR DESCRIPTION
## Summary
- add AppsGateway GetAppProfile client/hook
- resolve app sender identities to app profiles for chat message labels
- preserve existing fallback when app profile lookup fails

## Validation
- pnpm typecheck
- pnpm lint