### PR TITLE
Fix chat message tail pagination

### DIFF
--- a/src/api/hooks/chat.test.ts
+++ b/src/api/hooks/chat.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { chatApi } from '@/api/modules/chat';
+import { fetchChatMessagesPage, MESSAGE_ORDER_NEWEST_FIRST, MESSAGE_PAGE_SIZE } from './chat';
+
+vi.mock('@/api/modules/chat', () => ({
+  chatApi: {
+    getThreadMessages: vi.fn(),
+    getMessages: vi.fn(),
+  },
+}));
+
+const mockedChatApi = vi.mocked(chatApi);
+
+describe('fetchChatMessagesPage', () => {
+  beforeEach(() => {
+    mockedChatApi.getThreadMessages.mockReset();
+    mockedChatApi.getMessages.mockReset();
+  });
+
+  it('requests newest messages first and gets unread metadata for the initial page', async () => {
+    mockedChatApi.getThreadMessages.mockResolvedValueOnce({
+      messages: [
+        {
+          id: 'message-30',
+          chatId: 'thread-1',
+          senderId: 'user-1',
+          body: 'newest',
+          fileIds: [],
+          createdAt: '2026-05-22T12:30:00Z',
+        },
+      ],
+      nextPageToken: 'older-page',
+    });
+    mockedChatApi.getMessages.mockResolvedValueOnce({ messages: [], unreadCount: 3 });
+
+    const page = await fetchChatMessagesPage('thread-1');
+
+    expect(mockedChatApi.getThreadMessages).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      pageSize: MESSAGE_PAGE_SIZE,
+      pageToken: undefined,
+      order: MESSAGE_ORDER_NEWEST_FIRST,
+    });
+    expect(mockedChatApi.getMessages).toHaveBeenCalledWith({ chatId: 'thread-1', pageSize: 1 });
+    expect(page.unreadCount).toBe(3);
+    expect(page.nextPageToken).toBe('older-page');
+  });
+
+  it('uses the newest-first cursor for older history pages without refetching metadata', async () => {
+    mockedChatApi.getThreadMessages.mockResolvedValueOnce({
+      messages: [
+        {
+          id: 'message-29',
+          chatId: 'thread-1',
+          senderId: 'user-1',
+          body: 'older',
+          fileIds: [],
+          createdAt: '2026-05-22T12:29:00Z',
+        },
+      ],
+    });
+
+    await fetchChatMessagesPage('thread-1', 'older-page');
+
+    expect(mockedChatApi.getThreadMessages).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      pageSize: MESSAGE_PAGE_SIZE,
+      pageToken: 'older-page',
+      order: MESSAGE_ORDER_NEWEST_FIRST,
+    });
+    expect(mockedChatApi.getMessages).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/hooks/chat.ts
+++ b/src/api/hooks/chat.ts
@@ -13,7 +13,8 @@ import type {
   UpdateChatResponse,
 } from '@/api/types/chat';
 const CHAT_PAGE_SIZE = 25;
-const MESSAGE_PAGE_SIZE = 30;
+export const MESSAGE_PAGE_SIZE = 30;
+export const MESSAGE_ORDER_NEWEST_FIRST = 'MESSAGE_ORDER_NEWEST_FIRST' as const;
 
 export function useChats(organizationId: string | undefined) {
   return useInfiniteQuery({
@@ -32,16 +33,31 @@ export function useChats(organizationId: string | undefined) {
   });
 }
 
+export function fetchChatMessagesPage(chatId: string, pageToken?: string): Promise<GetMessagesResponse> {
+  return chatApi.getThreadMessages({
+    threadId: chatId,
+    pageSize: MESSAGE_PAGE_SIZE,
+    pageToken,
+    order: MESSAGE_ORDER_NEWEST_FIRST,
+  }).then(async (page) => {
+    if (pageToken !== undefined) return page;
+
+    const metadata = await chatApi.getMessages({
+      chatId,
+      pageSize: 1,
+    });
+    return {
+      ...page,
+      unreadCount: metadata.unreadCount ?? 0,
+    };
+  });
+}
+
 export function useChatMessages(chatId: string | null | undefined) {
   return useInfiniteQuery({
     enabled: Boolean(chatId),
     queryKey: ['chats', chatId ?? 'none', 'messages', MESSAGE_PAGE_SIZE],
-    queryFn: ({ pageParam }) =>
-      chatApi.getMessages({
-        chatId: chatId as string,
-        pageSize: MESSAGE_PAGE_SIZE,
-        pageToken: pageParam ?? undefined,
-      }),
+    queryFn: ({ pageParam }) => fetchChatMessagesPage(chatId as string, pageParam ?? undefined),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextPageToken ?? undefined,
     staleTime: 5000,

--- a/src/api/modules/chat.test.ts
+++ b/src/api/modules/chat.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { chatApi } from './chat';
+import { connectPost } from '@/api/connect';
+
+vi.mock('@/api/connect', () => ({
+  connectPost: vi.fn(),
+}));
+
+const mockedConnectPost = vi.mocked(connectPost);
+
+describe('chatApi', () => {
+  beforeEach(() => {
+    mockedConnectPost.mockReset();
+  });
+
+  it('loads thread messages through ThreadsGateway with newest-first ordering', async () => {
+    mockedConnectPost.mockResolvedValueOnce({
+      messages: [
+        {
+          id: 'message-2',
+          threadId: 'thread-1',
+          senderId: 'user-1',
+          body: 'latest',
+          createdAt: '2026-05-22T12:01:00Z',
+        },
+      ],
+      nextPageToken: 'older-page',
+    });
+
+    const response = await chatApi.getThreadMessages({
+      threadId: 'thread-1',
+      pageSize: 30,
+      pageToken: 'cursor-1',
+      order: 'MESSAGE_ORDER_NEWEST_FIRST',
+    });
+
+    expect(mockedConnectPost).toHaveBeenCalledWith(
+      '/api/agynio.api.gateway.v1.ThreadsGateway',
+      'GetMessages',
+      {
+        threadId: 'thread-1',
+        pageSize: 30,
+        pageToken: 'cursor-1',
+        order: 'MESSAGE_ORDER_NEWEST_FIRST',
+      },
+    );
+    expect(response).toEqual({
+      messages: [
+        {
+          id: 'message-2',
+          chatId: 'thread-1',
+          senderId: 'user-1',
+          body: 'latest',
+          fileIds: [],
+          createdAt: '2026-05-22T12:01:00Z',
+        },
+      ],
+      nextPageToken: 'older-page',
+    });
+  });
+});

--- a/src/api/modules/chat.ts
+++ b/src/api/modules/chat.ts
@@ -10,6 +10,8 @@ import type {
   GetChatsResponse,
   GetMessagesRequest,
   GetMessagesResponse,
+  GetThreadMessagesRequest,
+  GetThreadMessagesResponse,
   MarkAsReadRequest,
   MarkAsReadResponse,
   SendMessageRequest,
@@ -19,6 +21,7 @@ import type {
 } from '@/api/types/chat';
 
 const CHAT_SERVICE = '/api/agynio.api.gateway.v1.ChatGateway';
+const THREADS_SERVICE = '/api/agynio.api.gateway.v1.ThreadsGateway';
 
 type ProtoStatus = 'CHAT_STATUS_OPEN' | 'CHAT_STATUS_CLOSED';
 type ProtoActivityStatus =
@@ -58,8 +61,24 @@ function localStatusToProto(status?: ChatStatus): ProtoStatus | undefined {
   return status === 'closed' ? 'CHAT_STATUS_CLOSED' : 'CHAT_STATUS_OPEN';
 }
 
+type ThreadMessageWire = Omit<ChatMessage, 'chatId'> & {
+  threadId?: string;
+  chatId?: string;
+};
+
 function normalizeMessage(message: ChatMessage): ChatMessage {
   return { ...message, fileIds: message.fileIds ?? [] };
+}
+
+function normalizeThreadMessage(message: ThreadMessageWire): ChatMessage {
+  return {
+    id: message.id,
+    chatId: message.chatId ?? message.threadId ?? '',
+    senderId: message.senderId,
+    body: message.body,
+    fileIds: message.fileIds ?? [],
+    createdAt: message.createdAt,
+  };
 }
 
 function normalizeChat(chat: ChatWire): Chat {
@@ -91,6 +110,17 @@ export const chatApi = {
     return {
       ...resp,
       messages: (resp.messages ?? []).map(normalizeMessage),
+    };
+  },
+  getThreadMessages: async (req: GetThreadMessagesRequest): Promise<GetThreadMessagesResponse> => {
+    const resp = await connectPost<GetThreadMessagesRequest, { messages?: ThreadMessageWire[]; nextPageToken?: string }>(
+      THREADS_SERVICE,
+      'GetMessages',
+      req,
+    );
+    return {
+      ...resp,
+      messages: (resp.messages ?? []).map(normalizeThreadMessage),
     };
   },
   sendMessage: async (req: SendMessageRequest): Promise<SendMessageResponse> => {

--- a/src/api/types/chat.ts
+++ b/src/api/types/chat.ts
@@ -36,11 +36,18 @@ export type GetChatsRequest = { organizationId: string; pageSize?: number; pageT
 export type GetChatsResponse = { chats: Chat[]; nextPageToken?: string };
 
 export type GetMessagesRequest = { chatId: string; pageSize?: number; pageToken?: string };
+export type GetThreadMessagesRequest = {
+  threadId: string;
+  pageSize?: number;
+  pageToken?: string;
+  order?: 'MESSAGE_ORDER_OLDEST_FIRST' | 'MESSAGE_ORDER_NEWEST_FIRST';
+};
 export type GetMessagesResponse = {
   messages: ChatMessage[];
   nextPageToken?: string;
   unreadCount?: number;
 };
+export type GetThreadMessagesResponse = Omit<GetMessagesResponse, 'unreadCount'>;
 
 export type SendMessageRequest = { chatId: string; body?: string; fileIds?: string[] };
 export type SendMessageResponse = { message: ChatMessage };


### PR DESCRIPTION
## Summary
- Load conversation message bodies from `ThreadsGateway.GetMessages` with `MESSAGE_ORDER_NEWEST_FIRST` so the initial page is the latest N messages.
- Keep the rendered chat order chronological (oldest top, newest bottom) by preserving the existing client-side ascending sort.
- Fetch `unreadCount` metadata from `ChatGateway.GetMessages` on the initial page, since Chat still owns that UI-specific metadata.
- Add regression coverage for newest-first message requests and older-history pagination cursors.

## Architecture check
- Checked `agynio/architecture` before changing behavior. Chat is documented as a consumer of Threads for message storage/retrieval, and Threads `GetMessages` is read-only/paginated.
- Also verified `agynio/api` / service implementations: Threads already supports `MessageOrder`, while Chat `GetMessages` does not expose that order field. The app therefore uses the existing Threads gateway for ordered message bodies and keeps Chat for unread metadata.

## PR #95 verification
- PR #95 improves cache-key/cursor isolation and auto-fetches when a cached page does not fill the scroll container.
- It does not fix this bug because it still retrieves the first page through Chat's default oldest-first pagination.

## Validation
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --config.verify-deps-before-run=false test`
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --config.verify-deps-before-run=false typecheck`
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --config.verify-deps-before-run=false lint`
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --config.verify-deps-before-run=false build`
