### PR TITLE
ci: remove E2E ref override

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -111,7 +111,6 @@ jobs:
         uses: agynio/e2e/.github/actions/run-tests@main
         with:
           service: chat_app
-          ref: jules/remove-chat-trace-link-tests
           include_smoke: 'false'
 
       - name: Restore ArgoCD auto-sync


### PR DESCRIPTION
## Summary
- Remove the hard-coded `ref` input from the E2E workflow's `run-tests` action call.
- Let `agynio/e2e/.github/actions/run-tests@main` use its default reference behavior.

Closes #103

## Test & Lint Summary
- `pnpm lint`: passed with no errors
- `pnpm typecheck`: passed
- `pnpm test`: 56 passed, 0 failed, 0 skipped
- `pnpm build`: passed