### PR TITLE
fix: guard release publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,9 +15,16 @@ env:
   CHART_REGISTRY: oci://ghcr.io/agynio/charts
 
 jobs:
+  guard:
+    name: Verify release tag
+    uses: agynio/.github/.github/workflows/release-tag-guard.yml@main
+    permissions:
+      contents: read
+
   image:
     name: Build and push container image
     runs-on: ubuntu-latest
+    needs: guard
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -83,20 +90,12 @@ jobs:
   helm:
     name: Package and push Helm chart
     runs-on: ubuntu-latest
-    needs: image
+    needs:
+      - guard
+      - image
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Determine release version
-        id: version
-        run: |
-          if [[ "${GITHUB_REF_NAME}" != v*.*.* ]]; then
-            echo "Release tags must follow v*.*.*" >&2
-            exit 1
-          fi
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -118,10 +117,10 @@ jobs:
           mkdir -p dist
           helm package "$CHART_DIR" \
             --destination dist \
-            --version "${{ steps.version.outputs.version }}" \
-            --app-version "${{ steps.version.outputs.version }}"
+            --version "${{ needs.guard.outputs.version }}" \
+            --app-version "${{ needs.guard.outputs.version }}"
 
       - name: Push chart
         run: |
           CHART_NAME="$(basename "$CHART_DIR")"
-          helm push "dist/${CHART_NAME}-${{ steps.version.outputs.version }}.tgz" "$CHART_REGISTRY"
+          helm push "dist/${CHART_NAME}-${{ needs.guard.outputs.version }}.tgz" "$CHART_REGISTRY"


### PR DESCRIPTION
## Summary
- Adds a release guard job using the shared `agynio/.github` reusable workflow.
- Makes image publishing depend on the guard, so Docker login/build/push cannot run until the tag is verified.
- Makes Helm publishing depend on both the guard and image job, and reuses the guarded version output for chart packaging/push.

## Validation
- `actionlint`
- `helm dependency build charts/chat-app`
- `helm lint charts/chat-app` (1 chart linted, 0 failed)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (56 passed, 0 failed, 0 skipped)
- `VITE_API_BASE_URL=/api pnpm build`
- `/workspace/.github/scripts/validate-release-tag-guard.sh /workspace/chat-app v0.4.18 main` failed as expected before any publish/login step would run.
- Local temporary tag `v999.999.999` on `origin/main` passed the same guard check.

Depends on shared guard PR: https://github.com/agynio/.github/pull/2
Related: agynio/.github#1