### PR TITLE
feat(auth): request configured OIDC resource

### DIFF
--- a/charts/chat-app/Chart.yaml
+++ b/charts/chat-app/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: chat-app
 description: Helm chart for deploying the agyn Chat App.
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.4.19
+appVersion: 0.4.19
 home: https://github.com/agynio/chat-app
 sources:
   - https://github.com/agynio/chat-app

--- a/charts/chat-app/values.yaml
+++ b/charts/chat-app/values.yaml
@@ -83,6 +83,8 @@ env:
     value: "{{ .Values.origin }}"
   - name: OIDC_SCOPE
     value: "{{ .Values.oidcScope }}"
+  - name: OIDC_RESOURCE
+    value: "{{ .Values.oidcResource }}"
   - name: API_BASE_URL
     value: "{{ .Values.apiBaseUrl }}"
   - name: MEDIA_PROXY_URL
@@ -202,6 +204,7 @@ metrics:
 oidcAuthority: ""
 oidcClientId: ""
 oidcScope: "openid profile email offline_access"
+oidcResource: ""
 apiBaseUrl: /api
 origin: ""
 mediaProxyUrl: ""

--- a/src/auth/user-manager.ts
+++ b/src/auth/user-manager.ts
@@ -8,6 +8,7 @@ export const userManager = oidcConfig.enabled
       redirect_uri: `${window.location.origin}/callback`,
       post_logout_redirect_uri: window.location.origin,
       scope: oidcConfig.scope,
+      resource: oidcConfig.resource ?? undefined,
       response_type: 'code',
       userStore: new WebStorageStateStore({ store: window.sessionStorage }),
       automaticSilentRenew: true,

--- a/src/auth/user-manager.ts
+++ b/src/auth/user-manager.ts
@@ -12,14 +12,6 @@ export const userManager = oidcConfig.enabled
       response_type: 'code',
       userStore: new WebStorageStateStore({ store: window.sessionStorage }),
       automaticSilentRenew: true,
-      metadata: {
-        issuer: oidcConfig.authority,
-        authorization_endpoint: `${oidcConfig.authority}/authorize`,
-        token_endpoint: `${oidcConfig.authority}/token`,
-        end_session_endpoint: `${oidcConfig.authority}/end-session`,
-        userinfo_endpoint: `${oidcConfig.authority}/userinfo`,
-        jwks_uri: `${oidcConfig.authority}/jwks.json`,
-      },
     })
   : null;
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -9,7 +9,7 @@ type LocationStub = {
 
 type WindowStub = {
   location: LocationStub;
-  __APP_CONFIG: { API_BASE_URL: string };
+  __APP_CONFIG: Record<string, string>;
 };
 
 let deriveMediaProxyUrl: () => string | null;
@@ -98,5 +98,28 @@ describe('deriveTracingAppUrl', () => {
       setLocation(url);
       expect(deriveTracingAppUrl()).toBe(tracing);
     }
+  });
+});
+
+describe('oidcConfig', () => {
+  it('reads runtime OIDC resource', async () => {
+    windowStub.__APP_CONFIG = {
+      API_BASE_URL: '/api',
+      OIDC_AUTHORITY: 'https://auth.example.com',
+      OIDC_CLIENT_ID: 'chat-client',
+      OIDC_SCOPE: 'openid profile',
+      OIDC_RESOURCE: 'https://api.example.com',
+    };
+    vi.resetModules();
+
+    const mod = await import('./config');
+
+    expect(mod.oidcConfig).toEqual({
+      enabled: true,
+      authority: 'https://auth.example.com',
+      clientId: 'chat-client',
+      scope: 'openid profile',
+      resource: 'https://api.example.com',
+    });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ type RuntimeConfig = {
   OIDC_AUTHORITY?: string;
   OIDC_CLIENT_ID?: string;
   OIDC_SCOPE?: string;
+  OIDC_RESOURCE?: string;
 };
 
 type ViteEnv = {
@@ -17,6 +18,7 @@ type ViteEnv = {
   VITE_OIDC_AUTHORITY?: string;
   VITE_OIDC_CLIENT_ID?: string;
   VITE_OIDC_SCOPE?: string;
+  VITE_OIDC_RESOURCE?: string;
 };
 
 type OidcConfigEnabled = {
@@ -24,6 +26,7 @@ type OidcConfigEnabled = {
   authority: string;
   clientId: string;
   scope: string;
+  resource: string | null;
 };
 
 type OidcConfigDisabled = {
@@ -140,6 +143,7 @@ export const oidcConfig: OidcConfig = oidcEnabled
       authority: requireConfig('OIDC_AUTHORITY', rawOidcAuthority),
       clientId: requireConfig('OIDC_CLIENT_ID', readConfigValue('OIDC_CLIENT_ID', 'VITE_OIDC_CLIENT_ID')),
       scope: requireConfig('OIDC_SCOPE', readConfigValue('OIDC_SCOPE', 'VITE_OIDC_SCOPE')),
+      resource: readConfigValue('OIDC_RESOURCE', 'VITE_OIDC_RESOURCE'),
     }
   : { enabled: false };
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_OIDC_AUTHORITY?: string;
   readonly VITE_OIDC_CLIENT_ID?: string;
   readonly VITE_OIDC_SCOPE?: string;
+  readonly VITE_OIDC_RESOURCE?: string;
   readonly VITE_UI_MOCK_SIDEBAR?: string;
 }
 interface ImportMeta {
@@ -21,5 +22,6 @@ interface Window {
     OIDC_AUTHORITY?: string;
     OIDC_CLIENT_ID?: string;
     OIDC_SCOPE?: string;
+    OIDC_RESOURCE?: string;
   };
 }


### PR DESCRIPTION
## Summary

Supports agynio/infrastructure#22 and agynio/infrastructure#23 by making the Logto API resource indicator functional instead of an inert chart value.

This PR wires the OIDC resource/audience through this repository's runtime/chart contract so the platform chart can pass `https://agyn.cloud` from the Logto workspace outputs.

## Validation

See the parent infrastructure PR for the full cross-repository validation summary.
