### PR TITLE
ci(e2e): provision the platform VM instead of bootstrap

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,22 +45,10 @@ jobs:
 
       - name: Provision cluster
         id: provision_cluster
-        uses: agynio/bootstrap/.github/actions/provision@main
+        uses: agynio/e2e/.github/actions/provision-vm@main
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
-
-      - name: Disable ArgoCD auto-sync
-        shell: bash
-        run: |
-          set -euo pipefail
-          if kubectl get application chat-app -n argocd >/dev/null 2>&1; then
-            kubectl patch application chat-app -n argocd \
-              --type merge \
-              -p '{"spec":{"syncPolicy":{"automated":null}}}'
-          else
-            echo "WARNING: ArgoCD Application 'chat-app' not found."
-          fi
 
       - name: Allow devspace sync into nginx html
         shell: bash
@@ -112,16 +100,3 @@ jobs:
         with:
           service: chat_app
           include_smoke: 'false'
-
-      - name: Restore ArgoCD auto-sync
-        if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-          if kubectl get application chat-app -n argocd >/dev/null 2>&1; then
-            kubectl patch application chat-app -n argocd \
-              --type merge \
-              -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
-          else
-            echo "WARNING: ArgoCD Application 'chat-app' not found."
-          fi

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -23,7 +23,6 @@ dev:
     namespace: ${APP_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: chat-app
-      app.kubernetes.io/instance: chat-app
     containers:
       chat-app:
         sync:


### PR DESCRIPTION
Swaps cluster provisioning from `agynio/bootstrap/.github/actions/provision` to `agynio/e2e/.github/actions/provision-vm`, which boots the prebuilt platform VM and exports the same environment `run-tests` already reads.

Part of retiring `agynio/bootstrap`.