### PR TITLE
fix(auth): use OIDC discovery instead of hardcoded mockauth endpoints

### DIFF
--- a/charts/chat-app/Chart.yaml
+++ b/charts/chat-app/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: chat-app
 description: Helm chart for deploying the agyn Chat App.
 type: application
-version: 0.4.19
-appVersion: 0.4.19
+version: 0.1.0
+appVersion: 0.1.0
 home: https://github.com/agynio/chat-app
 sources:
   - https://github.com/agynio/chat-app

--- a/charts/chat-app/Chart.yaml
+++ b/charts/chat-app/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: chat-app
 description: Helm chart for deploying the agyn Chat App.
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.4.19
+appVersion: 0.4.19
 home: https://github.com/agynio/chat-app
 sources:
   - https://github.com/agynio/chat-app

--- a/charts/chat-app/values.yaml
+++ b/charts/chat-app/values.yaml
@@ -83,6 +83,8 @@ env:
     value: "{{ .Values.origin }}"
   - name: OIDC_SCOPE
     value: "{{ .Values.oidcScope }}"
+  - name: OIDC_RESOURCE
+    value: "{{ .Values.oidcResource }}"
   - name: API_BASE_URL
     value: "{{ .Values.apiBaseUrl }}"
   - name: MEDIA_PROXY_URL
@@ -202,6 +204,7 @@ metrics:
 oidcAuthority: ""
 oidcClientId: ""
 oidcScope: "openid profile email offline_access"
+oidcResource: ""
 apiBaseUrl: /api
 origin: ""
 mediaProxyUrl: ""

--- a/src/auth/user-manager.ts
+++ b/src/auth/user-manager.ts
@@ -8,6 +8,7 @@ export const userManager = oidcConfig.enabled
       redirect_uri: `${window.location.origin}/callback`,
       post_logout_redirect_uri: window.location.origin,
       scope: oidcConfig.scope,
+      resource: oidcConfig.resource ?? undefined,
       response_type: 'code',
       userStore: new WebStorageStateStore({ store: window.sessionStorage }),
       automaticSilentRenew: true,

--- a/src/auth/user-manager.ts
+++ b/src/auth/user-manager.ts
@@ -12,14 +12,6 @@ export const userManager = oidcConfig.enabled
       response_type: 'code',
       userStore: new WebStorageStateStore({ store: window.sessionStorage }),
       automaticSilentRenew: true,
-      metadata: {
-        issuer: oidcConfig.authority,
-        authorization_endpoint: `${oidcConfig.authority}/authorize`,
-        token_endpoint: `${oidcConfig.authority}/token`,
-        end_session_endpoint: `${oidcConfig.authority}/end-session`,
-        userinfo_endpoint: `${oidcConfig.authority}/userinfo`,
-        jwks_uri: `${oidcConfig.authority}/jwks.json`,
-      },
     })
   : null;
 

--- a/src/auth/user-manager.ts
+++ b/src/auth/user-manager.ts
@@ -8,7 +8,9 @@ export const userManager = oidcConfig.enabled
       redirect_uri: `${window.location.origin}/callback`,
       post_logout_redirect_uri: window.location.origin,
       scope: oidcConfig.scope,
+      // `resource` skips the code->token exchange; extraTokenParams forces it in.
       resource: oidcConfig.resource ?? undefined,
+      extraTokenParams: oidcConfig.resource ? { resource: oidcConfig.resource } : {},
       response_type: 'code',
       userStore: new WebStorageStateStore({ store: window.sessionStorage }),
       automaticSilentRenew: true,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -9,7 +9,7 @@ type LocationStub = {
 
 type WindowStub = {
   location: LocationStub;
-  __APP_CONFIG: { API_BASE_URL: string };
+  __APP_CONFIG: Record<string, string>;
 };
 
 let deriveMediaProxyUrl: () => string | null;
@@ -98,5 +98,28 @@ describe('deriveTracingAppUrl', () => {
       setLocation(url);
       expect(deriveTracingAppUrl()).toBe(tracing);
     }
+  });
+});
+
+describe('oidcConfig', () => {
+  it('reads runtime OIDC resource', async () => {
+    windowStub.__APP_CONFIG = {
+      API_BASE_URL: '/api',
+      OIDC_AUTHORITY: 'https://auth.example.com',
+      OIDC_CLIENT_ID: 'chat-client',
+      OIDC_SCOPE: 'openid profile',
+      OIDC_RESOURCE: 'https://api.example.com',
+    };
+    vi.resetModules();
+
+    const mod = await import('./config');
+
+    expect(mod.oidcConfig).toEqual({
+      enabled: true,
+      authority: 'https://auth.example.com',
+      clientId: 'chat-client',
+      scope: 'openid profile',
+      resource: 'https://api.example.com',
+    });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ type RuntimeConfig = {
   OIDC_AUTHORITY?: string;
   OIDC_CLIENT_ID?: string;
   OIDC_SCOPE?: string;
+  OIDC_RESOURCE?: string;
 };
 
 type ViteEnv = {
@@ -17,6 +18,7 @@ type ViteEnv = {
   VITE_OIDC_AUTHORITY?: string;
   VITE_OIDC_CLIENT_ID?: string;
   VITE_OIDC_SCOPE?: string;
+  VITE_OIDC_RESOURCE?: string;
 };
 
 type OidcConfigEnabled = {
@@ -24,6 +26,7 @@ type OidcConfigEnabled = {
   authority: string;
   clientId: string;
   scope: string;
+  resource: string | null;
 };
 
 type OidcConfigDisabled = {
@@ -140,6 +143,7 @@ export const oidcConfig: OidcConfig = oidcEnabled
       authority: requireConfig('OIDC_AUTHORITY', rawOidcAuthority),
       clientId: requireConfig('OIDC_CLIENT_ID', readConfigValue('OIDC_CLIENT_ID', 'VITE_OIDC_CLIENT_ID')),
       scope: requireConfig('OIDC_SCOPE', readConfigValue('OIDC_SCOPE', 'VITE_OIDC_SCOPE')),
+      resource: readConfigValue('OIDC_RESOURCE', 'VITE_OIDC_RESOURCE'),
     }
   : { enabled: false };
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_OIDC_AUTHORITY?: string;
   readonly VITE_OIDC_CLIENT_ID?: string;
   readonly VITE_OIDC_SCOPE?: string;
+  readonly VITE_OIDC_RESOURCE?: string;
   readonly VITE_UI_MOCK_SIDEBAR?: string;
 }
 interface ImportMeta {
@@ -21,5 +22,6 @@ interface Window {
     OIDC_AUTHORITY?: string;
     OIDC_CLIENT_ID?: string;
     OIDC_SCOPE?: string;
+    OIDC_RESOURCE?: string;
   };
 }


### PR DESCRIPTION
Supersedes #107 (contains both of its commits, plus two fixes).

## Problem

`user-manager.ts` passed an explicit `metadata` block to `oidc-client-ts`, which
disables discovery entirely and pins these paths:

    ${authority}/authorize   ${authority}/token   ${authority}/userinfo
    ${authority}/jwks.json   ${authority}/end-session

Those are mockauth-shaped. Keycloak serves
`/realms/{realm}/protocol/openid-connect/{auth,token,userinfo,certs,logout}`, so
`${authority}/authorize` 404s. Google, Auth0, Okta and Entra all differ too — chat-app
worked against mockauth and nothing else. console-app and tracing-app were never
affected; they use discovery.

## Changes

- Drop the `metadata` block so discovery runs (from #107).
- Add `OIDC_RESOURCE` plumbing to config and chart (from #107).
- Send `resource` in the code->token exchange via `extraTokenParams`. `resource`
  alone reaches the authorize redirect and refresh calls, but `_processCode` builds
  the token request from a fixed list plus `...state.extraTokenParams` only — same
  fix as console-app 97e9240.
- Revert the stray `Chart.yaml` bump to `0.4.19`; release.yaml passes
  `--version`/`--app-version` from the tag, and main keeps the `0.1.0` placeholder.

## Verification

Against the running local bundle VM, at chat-app's deployed `OIDC_AUTHORITY`:

- discovery returns HTTP 200
- `issuer` is byte-identical to the configured authority, so ID-token `iss`
  validation still passes
- all five endpoints match the previously hardcoded ones exactly — a no-op against
  mockauth
- CORS reflects `https://chat.agyn.dev:2496` on both preflight (204) and GET (200),
  which matters because discovery is a cross-origin fetch chat-app never made before

Local: typecheck, lint, 57 tests, build all pass.