### PR TITLE
fix(chat): refresh agent instances when a thread mints one

### DIFF
--- a/src/api/hooks/chat.test.ts
+++ b/src/api/hooks/chat.test.ts
@@ -1,13 +1,16 @@
-import { QueryClient, type InfiniteData } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider, type InfiniteData } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { chatApi } from '@/api/modules/chat';
-import type { GetMessagesResponse } from '@/api/types/chat';
-import { fetchChatMessagesPage, MESSAGE_ORDER_NEWEST_FIRST, MESSAGE_PAGE_SIZE } from './chat';
+import type { Chat, GetMessagesResponse } from '@/api/types/chat';
+import { fetchChatMessagesPage, MESSAGE_ORDER_NEWEST_FIRST, MESSAGE_PAGE_SIZE, useCreateChat } from './chat';
 
 vi.mock('@/api/modules/chat', () => ({
   chatApi: {
     getThreadMessages: vi.fn(),
     getMessages: vi.fn(),
+    createChat: vi.fn(),
   },
 }));
 
@@ -74,6 +77,37 @@ describe('fetchChatMessagesPage', () => {
   });
 });
 
+
+describe('useCreateChat', () => {
+  it('invalidates agent instances so the instance minted for the new thread resolves', async () => {
+    const chat: Chat = {
+      id: 'thread-1',
+      organizationId: 'org-1',
+      participants: [{ id: 'instance-1', joinedAt: '2026-05-22T12:30:00Z' }],
+      createdAt: '2026-05-22T12:30:00Z',
+      updatedAt: '2026-05-22T12:30:00Z',
+      status: 'open',
+      summary: null,
+      activityStatus: null,
+      unreadCount: 0,
+      activeWorkloadIds: [],
+    };
+    mockedChatApi.createChat.mockResolvedValueOnce({ chat });
+
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateQueries = vi.spyOn(client, 'invalidateQueries');
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client }, children);
+
+    const { result } = renderHook(() => useCreateChat('org-1'), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ participantIds: ['agent-1'] });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['chats', 'list', 'org-1'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['agent-instances'] });
+  });
+});
 
 describe('chat message pagination cache', () => {
   it('uses separate cache keys for each chat thread', async () => {

--- a/src/api/hooks/chat.ts
+++ b/src/api/hooks/chat.ts
@@ -175,6 +175,8 @@ export function useCreateChat(organizationId: string | undefined) {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['chats', 'list', organizationId] });
+      // Threads mints a fresh instance per agent added, so the cached list cannot name it yet.
+      queryClient.invalidateQueries({ queryKey: ['agent-instances'] });
     },
   });
 }

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -325,6 +325,25 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
     return map;
   }, [agents, agentInstances, agentNameByClassId, batchUsersQuery.data, user.identityId, user.name, userEmail]);
 
+  const refetchAgentInstances = instancesQuery.refetch;
+  const probedParticipantIdsRef = useRef<Set<string>>(new Set());
+
+  // A thread can name an instance minted after the last list fetch, so refetch
+  // once per unresolved participant instead of waiting for a reload.
+  useEffect(() => {
+    if (!batchUsersQuery.isFetched) return;
+    let hasUnresolved = false;
+    for (const chat of chatSummaries) {
+      for (const participant of chat.participants) {
+        if (participantLookup.has(participant.id)) continue;
+        if (probedParticipantIdsRef.current.has(participant.id)) continue;
+        probedParticipantIdsRef.current.add(participant.id);
+        hasUnresolved = true;
+      }
+    }
+    if (hasUnresolved) void refetchAgentInstances();
+  }, [batchUsersQuery.isFetched, chatSummaries, participantLookup, refetchAgentInstances]);
+
   const draftParticipants = useMemo(() => activeDraft?.participants ?? EMPTY_PARTICIPANTS, [activeDraft]);
   const selectedParticipantIds = useMemo(
     () => new Set(draftParticipants.map((participant) => participant.id)),


### PR DESCRIPTION
## Problem

Starting a new thread showed `(unknown participant)` in the sidebar row and the header until the page was reloaded.

Threads mints a fresh agent instance for every agent added to a thread (`createAgentInstance` in threads/internal/server/server.go), so the thread `CreateThread` returns carries an instance id the cached `agent-instances` list has never seen. `useCreateChat` only invalidated `['chats','list']`, and `useAgentInstances` has no refetch trigger beyond a mount, so the name only appeared after a reload.

Follow-up to 1cc1026, which made *existing* instances resolve; this makes newly minted ones resolve too.

## Change

- `useCreateChat` also invalidates `['agent-instances']`.
- Threads that arrive from elsewhere (an agent opening one with you, a participant someone else adds) have no such hook, so an unresolved participant id triggers one instance refetch, tracked in a ref so an id that stays unresolvable cannot loop. Gated on the batch-users fetch settling so pending human participants do not fire a spurious call.

## Verification

- New unit test on `useCreateChat` asserting both invalidations.
- `pnpm test` 58/58, `pnpm typecheck`, `pnpm lint` all clean.
- Deployed to the local VM from source via `devspace dev` (chat.agyn.dev serves the dev tree); browser check done by the author, not automated.