### PR TITLE
Sign out against providers with no end session endpoint

### DIFF
--- a/src/auth/LogoutButton.tsx
+++ b/src/auth/LogoutButton.tsx
@@ -1,6 +1,7 @@
 import type { ButtonHTMLAttributes } from 'react';
 import { useAuth } from 'react-oidc-context';
 import { oidcConfig } from '@/config';
+import { signOut } from './sign-out';
 
 type LogoutButtonProps = ButtonHTMLAttributes<HTMLButtonElement>;
 
@@ -10,7 +11,7 @@ function OidcLogoutButton({ children = 'Sign out', onClick, type = 'button', ...
   const handleClick: LogoutButtonProps['onClick'] = (event) => {
     onClick?.(event);
     if (event?.defaultPrevented) return;
-    void auth.signoutRedirect();
+    void signOut(auth);
   };
 
   return (

--- a/src/auth/sign-out.test.ts
+++ b/src/auth/sign-out.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getMetadata = vi.fn();
+const replace = vi.fn();
+
+vi.mock('./user-manager', () => ({
+  userManager: { metadataService: { getMetadata } },
+}));
+
+vi.stubGlobal('window', { location: { origin: 'https://chat.agyn.dev:2496', replace } });
+
+const { signOut } = await import('./sign-out');
+
+function buildAuth() {
+  return { signoutRedirect: vi.fn().mockResolvedValue(undefined), removeUser: vi.fn().mockResolvedValue(undefined) };
+}
+
+describe('signOut', () => {
+  beforeEach(() => {
+    getMetadata.mockReset();
+    replace.mockReset();
+  });
+
+  it('redirects to the provider when it publishes an end session endpoint', async () => {
+    getMetadata.mockResolvedValue({ end_session_endpoint: 'https://auth.agyn.dev:2496/logout' });
+    const auth = buildAuth();
+
+    await signOut(auth);
+
+    expect(auth.signoutRedirect).toHaveBeenCalledOnce();
+    expect(auth.removeUser).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  // Dex publishes none and holds no browser session, so dropping the tokens is
+  // the whole sign-out. Redirecting anyway throws, and the app renders that as a
+  // sign-in failure.
+  it('signs out locally when the provider publishes no end session endpoint', async () => {
+    getMetadata.mockResolvedValue({ issuer: 'https://dex.agyn.dev:2496' });
+    const auth = buildAuth();
+
+    await signOut(auth);
+
+    expect(auth.removeUser).toHaveBeenCalledOnce();
+    expect(auth.signoutRedirect).not.toHaveBeenCalled();
+    expect(replace).toHaveBeenCalledWith('https://chat.agyn.dev:2496');
+  });
+
+  it('signs out locally when discovery cannot be read', async () => {
+    getMetadata.mockRejectedValue(new Error('network down'));
+    const auth = buildAuth();
+
+    await signOut(auth);
+
+    expect(auth.removeUser).toHaveBeenCalledOnce();
+    expect(auth.signoutRedirect).not.toHaveBeenCalled();
+  });
+});

--- a/src/auth/sign-out.ts
+++ b/src/auth/sign-out.ts
@@ -1,0 +1,38 @@
+import { userManager } from './user-manager';
+
+// Keycloak publishes end_session_endpoint and keeps a browser session that only
+// the redirect can end. Dex publishes neither, and signoutRedirect() throws on
+// the missing endpoint -- react-oidc-context catches that into auth.error, so a
+// sign-out that already succeeded renders the "We couldn't sign you in" screen.
+//
+// Discovery being unreachable counts as absent: signing out locally is the safe
+// answer when the provider cannot be asked.
+async function supportsProviderSignOut(): Promise<boolean> {
+  if (!userManager) return false;
+  try {
+    const metadata = await userManager.metadataService.getMetadata();
+    return Boolean(metadata.end_session_endpoint);
+  } catch (error) {
+    console.warn('Could not read OIDC discovery; signing out locally.', error);
+    return false;
+  }
+}
+
+type SignOutAuth = {
+  signoutRedirect: () => Promise<void>;
+  removeUser: () => Promise<void>;
+};
+
+/**
+ * Signs out at the provider when it holds a session, and locally when it does
+ * not. The local path navigates to the origin -- the same place the provider
+ * redirect lands -- so the app reloads without tokens and asks to sign in again.
+ */
+export async function signOut(auth: SignOutAuth): Promise<void> {
+  if (await supportsProviderSignOut()) {
+    await auth.signoutRedirect();
+    return;
+  }
+  await auth.removeUser();
+  window.location.replace(window.location.origin);
+}


### PR DESCRIPTION
`signoutRedirect()` throws when discovery carries no `end_session_endpoint`, and react-oidc-context turns that into `auth.error` — so a sign-out that had already dropped the tokens rendered the sign-in failure screen instead.

Providers differ: Keycloak publishes the endpoint and holds a browser session only the redirect can end; Dex publishes neither. Ask discovery which one this is, and where there is no session to end, drop the tokens and return to the origin — the same place the provider redirect lands.

Three tests cover the branches: endpoint present → redirect, absent → local sign-out, discovery unreachable → local sign-out.