### PR TITLE
feat(nav): take sibling product addresses from configuration

### DIFF
--- a/charts/chat-app/values.yaml
+++ b/charts/chat-app/values.yaml
@@ -87,8 +87,9 @@ env:
     value: "{{ .Values.oidcResource }}"
   - name: API_BASE_URL
     value: "{{ .Values.apiBaseUrl }}"
-  - name: MEDIA_PROXY_URL
-    value: "{{ .Values.mediaProxyUrl }}"
+# MEDIA_PROXY_URL, CHAT_URL, TRACING_URL, CONSOLE_URL and SANDBOXES_URL are
+# deliberately absent: an explicit empty env var shadows extraEnvVarsCM, which
+# is how the umbrella feeds them. Set them here via extraEnvVars standalone.
 envFrom: []
 extraEnvVars: []
 extraEnvVarsCM: ""
@@ -207,7 +208,6 @@ oidcScope: "openid profile email offline_access"
 oidcResource: ""
 apiBaseUrl: /api
 origin: ""
-mediaProxyUrl: ""
 
 nginx:
   port: 3000

--- a/docker/40-generate-config.sh
+++ b/docker/40-generate-config.sh
@@ -9,6 +9,10 @@ escape_js() {
 
 api_base_url=$(escape_js "${API_BASE_URL:-}")
 media_proxy_url=$(escape_js "${MEDIA_PROXY_URL:-}")
+chat_url=$(escape_js "${CHAT_URL:-}")
+tracing_url=$(escape_js "${TRACING_URL:-}")
+console_url=$(escape_js "${CONSOLE_URL:-}")
+sandboxes_url=$(escape_js "${SANDBOXES_URL:-}")
 oidc_authority=$(escape_js "${OIDC_AUTHORITY:-}")
 oidc_client_id=$(escape_js "${OIDC_CLIENT_ID:-}")
 oidc_scope=$(escape_js "${OIDC_SCOPE:-}")
@@ -17,6 +21,10 @@ cat > "$CONFIG_PATH" <<EOF
 window.__APP_CONFIG = {
   API_BASE_URL: "${api_base_url}",
   MEDIA_PROXY_URL: "${media_proxy_url}",
+  CHAT_URL: "${chat_url}",
+  TRACING_URL: "${tracing_url}",
+  CONSOLE_URL: "${console_url}",
+  SANDBOXES_URL: "${sandboxes_url}",
   OIDC_AUTHORITY: "${oidc_authority}",
   OIDC_CLIENT_ID: "${oidc_client_id}",
   OIDC_SCOPE: "${oidc_scope}",

--- a/src/components/screens/ChatsScreen.test.tsx
+++ b/src/components/screens/ChatsScreen.test.tsx
@@ -51,6 +51,7 @@ vi.mock('../ui/popover', () => ({
 
 vi.mock('@/config', () => ({
   oidcConfig: { enabled: false },
+  config: { productUrls: {} },
   deriveSiblingUrl: () => null,
 }));
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,10 @@
 type RuntimeConfig = {
   API_BASE_URL?: string;
   MEDIA_PROXY_URL?: string;
+  CHAT_URL?: string;
+  TRACING_URL?: string;
+  CONSOLE_URL?: string;
+  SANDBOXES_URL?: string;
   SOCKETS_ENABLED?: string;
   OIDC_AUTHORITY?: string;
   OIDC_CLIENT_ID?: string;
@@ -14,6 +18,10 @@ type RuntimeConfig = {
 type ViteEnv = {
   VITE_API_BASE_URL?: string;
   VITE_MEDIA_PROXY_URL?: string;
+  VITE_CHAT_URL?: string;
+  VITE_TRACING_URL?: string;
+  VITE_CONSOLE_URL?: string;
+  VITE_SANDBOXES_URL?: string;
   VITE_SOCKETS_ENABLED?: string;
   VITE_OIDC_AUTHORITY?: string;
   VITE_OIDC_CLIENT_ID?: string;
@@ -127,7 +135,21 @@ const mediaProxyUrl =
       ? deriveBase(rawMediaProxyUrl, { stripApi: false })
       : null;
 
-const tracingAppUrl = deriveTracingAppUrl();
+// Sibling product origins, keyed by product id. Set by the operator when the
+// apps are not served at <product>.<domain>; null falls back to derivation.
+const productUrls: Record<string, string | null> = {
+  chat: readProductUrl('CHAT_URL', 'VITE_CHAT_URL'),
+  tracing: readProductUrl('TRACING_URL', 'VITE_TRACING_URL'),
+  console: readProductUrl('CONSOLE_URL', 'VITE_CONSOLE_URL'),
+  sandboxes: readProductUrl('SANDBOXES_URL', 'VITE_SANDBOXES_URL'),
+};
+
+function readProductUrl(runtimeKey: keyof RuntimeConfig, envKey: keyof ViteEnv): string | null {
+  const value = readConfigValue(runtimeKey, envKey);
+  return value ? deriveBase(value, { stripApi: false }) : null;
+}
+
+const tracingAppUrl = productUrls.tracing ?? deriveTracingAppUrl();
 
 const rawSocketsEnabled = readConfigValue('SOCKETS_ENABLED', 'VITE_SOCKETS_ENABLED');
 const socketsEnabled = rawSocketsEnabled
@@ -150,6 +172,7 @@ export const oidcConfig: OidcConfig = oidcEnabled
 export const config = {
   apiBaseUrl,
   mediaProxyUrl,
+  productUrls,
   socketBaseUrl,
   socketsEnabled,
   tracingAppUrl,

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1,5 +1,5 @@
 import { Box, MessageCircle, SlidersVertical, TrendingUp, type LucideIcon } from 'lucide-react';
-import { deriveSiblingUrl } from '@/config';
+import { config, deriveSiblingUrl } from '@/config';
 
 export type Product = {
   id: string;
@@ -23,5 +23,6 @@ export const PRODUCTS: Product[] = [
 /** Null when the product is unreleased or the host has no derivable sibling. */
 export function productUrl(product: Product): string | null {
   if (product.comingSoon) return null;
-  return deriveSiblingUrl(product.subdomain);
+  // Derivation only holds when every app sits at <product>.<domain>.
+  return config.productUrls[product.id] ?? deriveSiblingUrl(product.subdomain);
 }

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -424,7 +424,7 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
   const resolveAgentSettingsUrl = useCallback(
     (participants: Chat['participants']) => {
       if (!organizationId) return undefined;
-      const consoleUrl = deriveSiblingUrl('console');
+      const consoleUrl = config.productUrls.console ?? deriveSiblingUrl('console');
       if (!consoleUrl) return undefined;
       const agentId = participants
         .map((participant) => instanceById.get(participant.id)?.agentId)


### PR DESCRIPTION
The product switcher built its links by replacing the first label of the current hostname with the sibling's name, which holds only while every app is served at `<product>.<domain>`. An install at `chat-agyn.example` derived `console.example` — a host that exists nowhere on it — so every entry led to a 404, along with the tracing link and the agent settings link out to the console.

The image offered no way to correct it: `__config.js` carried `API_BASE_URL`, `MEDIA_PROXY_URL` and the OIDC settings and nothing else.

Now reads `CHAT_URL`, `TRACING_URL`, `CONSOLE_URL` and `SANDBOXES_URL`, deriving only where one is unset, so default installs and devspace are untouched. The umbrella feeds them through `envFrom` from a ConfigMap it derives from the routes it already declares.

**Breaking, chart only.** `MEDIA_PROXY_URL` leaves the chart's `env:` block and the `mediaProxyUrl` value goes with it. An explicit empty variable shadows `extraEnvVarsCM`, so leaving it there would have kept the media proxy guessing while the other four were told. bundle-vm was the only caller and now sets `platform.externalUrls.mediaProxy`; anyone else setting `mediaProxyUrl` should move to `extraEnvVars` or the umbrella value.

Same change as agynio/console-app#143, which carries the tests for the shared logic.