### PR TITLE
Provision E2E on the platform VM

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Provision cluster
         id: provision_cluster
-        uses: agynio/bootstrap/.github/actions/provision@main
+        uses: agynio/e2e/.github/actions/provision-vm@main
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
@@ -66,8 +66,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          kubectl get deployment chat-app -n platform
-          kubectl patch deployment chat-app -n platform --type strategic \
+          kubectl get deployment chat-app -n agyn-platform
+          kubectl patch deployment chat-app -n agyn-platform --type strategic \
             -p "$(cat <<'EOF_PATCH'
           {
             "spec": {
@@ -102,7 +102,7 @@ jobs:
           }
           EOF_PATCH
           )"
-          kubectl rollout status deployment/chat-app -n platform --timeout=5m
+          kubectl rollout status deployment/chat-app -n agyn-platform --timeout=5m
 
       - name: Deploy from source
         run: devspace dev --pipeline dev

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,7 +1,7 @@
 version: v2beta1
 
 vars:
-  APP_NAMESPACE: platform
+  APP_NAMESPACE: agyn-platform
   # Carries Node and already ships in the VM's image store, so this pulls
   # nothing. Keep in sync with the image in patch_deployment below.
   DEV_IMAGE: ghcr.io/agynio/devcontainer-agyn:sha-f739923


### PR DESCRIPTION
`run-tests` moved to the VM's contract and reads `AGYN_API_TOKEN` from the environment. The bootstrap action never exported it, so every run since has died before a single test ran:

```
AGYN_API_TOKEN is not set; run a provisioning action before this one.
```

Both the nginx-html patch step and DevSpace follow the install to `agyn-platform`, which it moved to on 2026-08-09. `platform` is empty, so `kubectl get deployment chat-app -n platform` looked for a deployment that was no longer there — and under `set -e` that ends the job rather than the step.

Depends on agynio/e2e#255, which boots an image the upgrade can actually reach.

This gets the suite running again; it does not claim it all passes. The VM path last sat at 17/21, with the agent-reply specs failing on their own account.