### PR TITLE
Delete a conversation from the actions menu

### DIFF
--- a/src/api/errors.test.ts
+++ b/src/api/errors.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { isThreadDegradedError } from './errors';
+import { isChatNotFoundError, isThreadDegradedError } from './errors';
 
 const buildError = (data: unknown) => ({ response: { data } });
+
+describe('isChatNotFoundError', () => {
+  it('matches not found regardless of message', () => {
+    expect(isChatNotFoundError(buildError({ code: 'not_found', message: 'chat not found' }))).toBe(true);
+    expect(isChatNotFoundError(buildError({ code: 'NotFound' }))).toBe(true);
+  });
+
+  it('rejects other codes', () => {
+    expect(isChatNotFoundError(buildError({ code: 'permission_denied', message: 'chat not found' }))).toBe(false);
+    expect(isChatNotFoundError(new Error('chat not found'))).toBe(false);
+  });
+});
 
 describe('isThreadDegradedError', () => {
   it('matches failed precondition with exact message', () => {

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -79,6 +79,12 @@ export function resolveConnectErrorDetails(error: unknown): ConnectErrorDetails 
   return { code, message };
 }
 
+export function isChatNotFoundError(error: unknown): boolean {
+  const details = resolveConnectErrorDetails(error);
+  if (!details?.code) return false;
+  return normalizeConnectCode(details.code) === 'not_found';
+}
+
 export function isThreadDegradedError(error: unknown): boolean {
   const details = resolveConnectErrorDetails(error);
   if (!details?.code || details.message !== 'thread is degraded') return false;

--- a/src/api/hooks/chat.test.ts
+++ b/src/api/hooks/chat.test.ts
@@ -4,13 +4,20 @@ import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { chatApi } from '@/api/modules/chat';
 import type { Chat, GetMessagesResponse } from '@/api/types/chat';
-import { fetchChatMessagesPage, MESSAGE_ORDER_NEWEST_FIRST, MESSAGE_PAGE_SIZE, useCreateChat } from './chat';
+import {
+  fetchChatMessagesPage,
+  MESSAGE_ORDER_NEWEST_FIRST,
+  MESSAGE_PAGE_SIZE,
+  useCreateChat,
+  useDeleteChat,
+} from './chat';
 
 vi.mock('@/api/modules/chat', () => ({
   chatApi: {
     getThreadMessages: vi.fn(),
     getMessages: vi.fn(),
     createChat: vi.fn(),
+    deleteChat: vi.fn(),
   },
 }));
 
@@ -106,6 +113,67 @@ describe('useCreateChat', () => {
 
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['chats', 'list', 'org-1'] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['agent-instances'] });
+  });
+});
+
+describe('useDeleteChat', () => {
+  const chat = (id: string): Chat => ({
+    id,
+    organizationId: 'org-1',
+    participants: [],
+    createdAt: '2026-08-13T12:00:00Z',
+    updatedAt: '2026-08-13T12:00:00Z',
+    status: 'open',
+    summary: null,
+    activityStatus: null,
+    unreadCount: 0,
+    activeWorkloadIds: [],
+  });
+
+  const listKey = ['chats', 'list', 'org-1', 25];
+
+  const seedList = (client: QueryClient) => {
+    client.setQueryData<InfiniteData<GetChatsResponse>>(listKey, {
+      pageParams: [undefined],
+      pages: [{ chats: [chat('thread-1'), chat('thread-2')] }],
+    });
+    return ({ children }: { children: ReactNode }) => createElement(QueryClientProvider, { client }, children);
+  };
+
+  const listedIds = (client: QueryClient) =>
+    client
+      .getQueryData<InfiniteData<GetChatsResponse>>(listKey)
+      ?.pages.flatMap((page) => page.chats.map((entry) => entry.id));
+
+  beforeEach(() => {
+    mockedChatApi.deleteChat.mockReset();
+  });
+
+  it('drops the deleted chat from every cached list page', async () => {
+    mockedChatApi.deleteChat.mockResolvedValueOnce({});
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const wrapper = seedList(client);
+
+    const { result } = renderHook(() => useDeleteChat(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ chatId: 'thread-1' });
+    });
+
+    expect(mockedChatApi.deleteChat).toHaveBeenCalledWith({ chatId: 'thread-1' });
+    expect(listedIds(client)).toEqual(['thread-2']);
+  });
+
+  it('puts the chat back when the delete fails', async () => {
+    mockedChatApi.deleteChat.mockRejectedValueOnce(new Error('nope'));
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const wrapper = seedList(client);
+
+    const { result } = renderHook(() => useDeleteChat(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ chatId: 'thread-1' }).catch(() => {});
+    });
+
+    expect(listedIds(client)).toEqual(['thread-1', 'thread-2']);
   });
 });
 

--- a/src/api/hooks/chat.ts
+++ b/src/api/hooks/chat.ts
@@ -6,6 +6,7 @@ import type {
   ChatMessage,
   CreateChatRequest,
   CreateChatResponse,
+  DeleteChatResponse,
   GetChatsResponse,
   GetMessagesResponse,
   MarkAsReadResponse,
@@ -236,6 +237,45 @@ export function useUpdateChat() {
         updateChatPages(current, variables.chatId, data.chat),
       );
       queryClient.invalidateQueries({ queryKey });
+    },
+  });
+}
+
+type DeleteChatInput = { chatId: string };
+
+type DeleteChatContext = {
+  previousChats: Array<[unknown, InfiniteData<GetChatsResponse> | undefined]>;
+};
+
+export function useDeleteChat() {
+  const queryClient = useQueryClient();
+
+  return useMutation<DeleteChatResponse, Error, DeleteChatInput, DeleteChatContext>({
+    mutationFn: ({ chatId }) => chatApi.deleteChat({ chatId }),
+    onMutate: async ({ chatId }) => {
+      const queryKey = ['chats', 'list'];
+      await queryClient.cancelQueries({ queryKey });
+      const previousChats = queryClient.getQueriesData<InfiniteData<GetChatsResponse>>({ queryKey });
+      queryClient.setQueriesData<InfiniteData<GetChatsResponse>>({ queryKey }, (current) => {
+        if (!current) return current;
+        return {
+          ...current,
+          pages: current.pages.map((page) => ({
+            ...page,
+            chats: page.chats.filter((chat) => chat.id !== chatId),
+          })),
+        };
+      });
+      return { previousChats };
+    },
+    onError: (_error, _variables, context) => {
+      context?.previousChats.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
+    },
+    onSuccess: (_data, { chatId }) => {
+      queryClient.removeQueries({ queryKey: ['chats', chatId] });
+      queryClient.invalidateQueries({ queryKey: ['chats', 'list'] });
     },
   });
 }

--- a/src/api/modules/chat.test.ts
+++ b/src/api/modules/chat.test.ts
@@ -63,6 +63,16 @@ describe('chatApi', () => {
     );
   });
 
+  it('deletes chats through ChatGateway', async () => {
+    mockedConnectPost.mockResolvedValueOnce({});
+
+    await chatApi.deleteChat({ chatId: 'chat-1' });
+
+    expect(mockedConnectPost).toHaveBeenCalledWith('/api/agynio.api.gateway.v1.ChatGateway', 'DeleteChat', {
+      chatId: 'chat-1',
+    });
+  });
+
   it('loads thread messages through ThreadsGateway with newest-first ordering', async () => {
     mockedConnectPost.mockResolvedValueOnce({
       messages: [

--- a/src/api/modules/chat.ts
+++ b/src/api/modules/chat.ts
@@ -6,6 +6,8 @@ import type {
   ChatStatus,
   CreateChatRequest,
   CreateChatResponse,
+  DeleteChatRequest,
+  DeleteChatResponse,
   GetChatsRequest,
   GetChatsResponse,
   GetMessagesRequest,
@@ -149,6 +151,8 @@ export const chatApi = {
     const resp = await connectPost<UpdateChatRequestWire, UpdateChatResponse>(CHAT_SERVICE, 'UpdateChat', payload);
     return { ...resp, chat: normalizeChat(resp.chat) };
   },
+  deleteChat: (req: DeleteChatRequest): Promise<DeleteChatResponse> =>
+    connectPost<DeleteChatRequest, DeleteChatResponse>(CHAT_SERVICE, 'DeleteChat', req),
   markAsRead: (req: MarkAsReadRequest): Promise<MarkAsReadResponse> =>
     connectPost<MarkAsReadRequest, MarkAsReadResponse>(CHAT_SERVICE, 'MarkAsRead', req),
 };

--- a/src/api/types/chat.ts
+++ b/src/api/types/chat.ts
@@ -55,5 +55,8 @@ export type SendMessageResponse = { message: ChatMessage };
 export type UpdateChatRequest = { chatId: string; status?: ChatStatus; summary?: string };
 export type UpdateChatResponse = { chat: Chat };
 
+export type DeleteChatRequest = { chatId: string };
+export type DeleteChatResponse = Record<string, never>;
+
 export type MarkAsReadRequest = { chatId: string };
 export type MarkAsReadResponse = { readCount: number };

--- a/src/components/screens/ChatsScreen.test.tsx
+++ b/src/components/screens/ChatsScreen.test.tsx
@@ -31,7 +31,20 @@ vi.mock('../MarkdownComposer', () => ({
 vi.mock('../ui/dropdown-menu', () => ({
   DropdownMenu: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   DropdownMenuContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuItem: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    disabled,
+    ...props
+  }: {
+    children?: React.ReactNode;
+    onSelect?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" disabled={disabled} onClick={() => onSelect?.()} {...props}>
+      {children}
+    </button>
+  ),
   DropdownMenuLabel: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
   DropdownMenuRadioGroup: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
   DropdownMenuRadioItem: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
@@ -109,7 +122,7 @@ const runs: ChatRun[] = [
   },
 ];
 
-function TestHarness() {
+function TestHarness({ onDeleteChat }: { onDeleteChat?: (chatId: string) => void } = {}) {
   const [inputValue, setInputValue] = React.useState('');
   return (
     <ChatsScreen
@@ -123,6 +136,7 @@ function TestHarness() {
       currentUserId="user-1"
       onInputValueChange={setInputValue}
       onSendMessage={() => {}}
+      onDeleteChat={onDeleteChat}
     />
   );
 }
@@ -156,5 +170,33 @@ describe('ChatsScreen', () => {
     expect(chatRenderSpy).toHaveBeenCalledTimes(1);
     expect(markdownContentRenderSpy).toHaveBeenCalledTimes(1);
     expect(mediaRenderSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes the conversation only after the confirmation is accepted', () => {
+    const onDeleteChat = vi.fn();
+    render(
+      <ThemeProvider>
+        <TestHarness onDeleteChat={onDeleteChat} />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('chat-action-delete'));
+    expect(onDeleteChat).not.toHaveBeenCalled();
+
+    const dialog = screen.getByTestId('chat-delete-dialog');
+    expect(dialog).toHaveTextContent('Summary');
+
+    fireEvent.click(screen.getByTestId('chat-delete-confirm'));
+    expect(onDeleteChat).toHaveBeenCalledWith('chat-1');
+  });
+
+  it('leaves the delete action out of reach when the screen offers no delete handler', () => {
+    render(
+      <ThemeProvider>
+        <TestHarness />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId('chat-action-delete')).toBeDisabled();
   });
 });

--- a/src/components/screens/ChatsScreen.tsx
+++ b/src/components/screens/ChatsScreen.tsx
@@ -30,6 +30,17 @@ import {
   type ChatQueuedMessageData,
 } from '../Chat';
 import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../ui/alert-dialog';
+import { buttonVariants } from '../ui/button-variants';
 import { MarkdownComposer } from '../MarkdownComposer';
 import {
   DropdownMenu,
@@ -177,8 +188,10 @@ type ChatDetailHeaderProps = {
   reminders: { id: string; title: string; time: string }[];
   isToggleChatStatusPending: boolean;
   isUpdateSummaryPending: boolean;
+  isDeleteChatPending: boolean;
   onToggleChatStatus?: (chatId: string, nextStatus: 'open' | 'closed') => void;
   onUpdateSummary?: (chatId: string, summary: string) => void;
+  onDeleteChat?: (chatId: string) => void;
   onCancelReminder?: (reminderId: string) => void;
   cancellingReminderIds?: ReadonlySet<string>;
 };
@@ -202,14 +215,17 @@ function ChatDetailHeader({
   reminders,
   isToggleChatStatusPending,
   isUpdateSummaryPending,
+  isDeleteChatPending,
   onToggleChatStatus,
   onUpdateSummary,
+  onDeleteChat,
   onCancelReminder,
   cancellingReminderIds,
 }: ChatDetailHeaderProps) {
   const [isStatusMenuOpen, setIsStatusMenuOpen] = useState(false);
   const [isRemindersPopoverOpen, setIsRemindersPopoverOpen] = useState(false);
   const [isEditingSummary, setIsEditingSummary] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [summaryDraft, setSummaryDraft] = useState('');
   const summaryInputRef = useRef<HTMLInputElement | null>(null);
   const summaryCancelRef = useRef(false);
@@ -219,6 +235,7 @@ function ChatDetailHeader({
   useEffect(() => {
     setIsStatusMenuOpen(false);
     setIsRemindersPopoverOpen(false);
+    setIsDeleteDialogOpen(false);
     summaryCancelRef.current = false;
     setIsEditingSummary(false);
   }, [chat.id]);
@@ -265,6 +282,9 @@ function ChatDetailHeader({
   const canEditSummary = Boolean(onUpdateSummary) && !isUpdateSummaryPending;
   const chatTitle = chat.title?.trim() || UNKNOWN_PARTICIPANT_LABEL;
   const activityLabel = chat.status ? ACTIVITY_PILL_LABELS[chat.status] : undefined;
+  const canDeleteChat = Boolean(onDeleteChat) && !isDeleteChatPending;
+  // The list labels a conversation by its summary; fall back to participants when it has none.
+  const deleteChatLabel = hasSummary ? summaryValue : chatTitle;
 
   const handleSummaryCommit = () => {
     if (summaryCancelRef.current) {
@@ -477,8 +497,47 @@ function ChatDetailHeader({
                   </DropdownMenuItem>
                 </>
               ) : null}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                variant="destructive"
+                disabled={!canDeleteChat}
+                onSelect={() => setIsDeleteDialogOpen(true)}
+                data-testid="chat-action-delete"
+              >
+                <Trash2 className="h-4 w-4" />
+                <span>Delete conversation</span>
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+
+          <AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+            <AlertDialogContent data-testid="chat-delete-dialog">
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete conversation?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  <span className="font-medium text-foreground">{deleteChatLabel}</span> disappears for everyone in
+                  it and cannot be reopened from Chat.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={isDeleteChatPending}>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  className={buttonVariants({ variant: 'destructive' })}
+                  disabled={!canDeleteChat}
+                  aria-busy={isDeleteChatPending || undefined}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    if (!canDeleteChat) return;
+                    onDeleteChat?.(chat.id);
+                  }}
+                  data-testid="chat-delete-confirm"
+                >
+                  {isDeleteChatPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                  Delete
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </div>
       </div>
 
@@ -555,6 +614,8 @@ interface ChatsScreenProps {
   isToggleChatStatusPending?: boolean;
   onUpdateSummary?: (chatId: string, summary: string) => void;
   isUpdateSummaryPending?: boolean;
+  onDeleteChat?: (chatId: string) => void;
+  isDeleteChatPending?: boolean;
   isSendMessagePending?: boolean;
   isThreadDegraded?: boolean;
   currentUserId: string;
@@ -744,6 +805,8 @@ export default function ChatsScreen({
   isToggleChatStatusPending = false,
   onUpdateSummary,
   isUpdateSummaryPending = false,
+  onDeleteChat,
+  isDeleteChatPending = false,
   isSendMessagePending = false,
   isThreadDegraded = false,
   currentUserId,
@@ -888,8 +951,10 @@ export default function ChatsScreen({
           reminders={reminders}
           isToggleChatStatusPending={isToggleChatStatusPending}
           isUpdateSummaryPending={isUpdateSummaryPending}
+          isDeleteChatPending={isDeleteChatPending}
           onToggleChatStatus={onToggleChatStatus}
           onUpdateSummary={onUpdateSummary}
+          onDeleteChat={onDeleteChat}
           onCancelReminder={onCancelReminder}
           cancellingReminderIds={cancellingReminderIds}
         />

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -8,7 +8,7 @@ import { MessageAttachments } from '@/components/MessageAttachments';
 import ChatsScreen from '@/components/screens/ChatsScreen';
 import { SidebarUserMenu } from '@/components/SidebarUserMenu';
 import { notifyError } from '@/lib/notify';
-import { isThreadDegradedError } from '@/api/errors';
+import { isChatNotFoundError, isThreadDegradedError } from '@/api/errors';
 import { useUser } from '@/user/user.runtime';
 import { useOrganization } from '@/organization/organization.runtime';
 import { useFileAttachments } from '@/hooks/useFileAttachments';
@@ -20,6 +20,7 @@ import {
   useChats,
   useChatMessages,
   useCreateChat,
+  useDeleteChat,
   useSendMessage,
   useMarkAsRead,
   useUpdateChat,
@@ -515,6 +516,18 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
     fetchNextPage: fetchNextMessagesPage,
   } = chatMessagesQuery;
 
+  // A link to a deleted conversation has nothing to open; fall back to the list.
+  const chatMessagesError = chatMessagesQuery.error;
+  useEffect(() => {
+    if (!selectedChatId || effectiveDraftMode) return;
+    if (!isChatNotFoundError(chatMessagesError)) return;
+    setSelectedChatIdState(null);
+    void queryClient.invalidateQueries({ queryKey: ['chats', 'list'] });
+    if (params.chatId) {
+      navigate('/chats');
+    }
+  }, [chatMessagesError, selectedChatId, effectiveDraftMode, params.chatId, navigate, queryClient]);
+
   const remindersQuery = useChatReminders(
     effectiveDraftMode ? undefined : selectedChatId ?? undefined,
     !effectiveDraftMode,
@@ -556,6 +569,7 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
   const sendMessage = useSendMessage();
   const createChat = useCreateChat(organizationId);
   const updateChat = useUpdateChat();
+  const deleteChat = useDeleteChat();
 
   const chatMessages = useMemo(() => {
     const pages = chatMessagesQuery.data?.pages ?? [];
@@ -857,6 +871,31 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
     [updateChat],
   );
 
+  const handleDeleteChat = useCallback(
+    (chatId: string) => {
+      if (deleteChat.isPending) return;
+      deleteChat.mutate(
+        { chatId },
+        {
+          onSuccess: () => {
+            clearDraft(chatId, userEmail);
+            if (lastNonDraftIdRef.current === chatId) {
+              lastNonDraftIdRef.current = null;
+            }
+            setSelectedChatIdState(null);
+            if (params.chatId === chatId) {
+              navigate('/chats');
+            }
+          },
+          onError: (error) => {
+            notifyError(error instanceof Error ? error.message : 'Failed to delete conversation.');
+          },
+        },
+      );
+    },
+    [deleteChat, userEmail, lastNonDraftIdRef, params.chatId, navigate],
+  );
+
   const handleChatsLoadMore = useCallback(() => {
     if (chatsQuery.hasNextPage && !chatsQuery.isFetchingNextPage) {
       void chatsQuery.fetchNextPage();
@@ -1038,6 +1077,8 @@ function ChatsContent({ user }: { user: IdentifiedUser }) {
           isToggleChatStatusPending={canUpdateChat ? updateChat.isPending : false}
           onUpdateSummary={canUpdateChat ? handleUpdateSummary : undefined}
           isUpdateSummaryPending={canUpdateChat ? updateChat.isPending : false}
+          onDeleteChat={canUpdateChat ? handleDeleteChat : undefined}
+          isDeleteChatPending={canUpdateChat ? deleteChat.isPending : false}
           currentUserId={currentUserId}
           isSendMessagePending={sendMessage.isPending || createChat.isPending}
           isThreadDegraded={isThreadDegraded}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,3 +1,9 @@
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// Without vitest globals, testing-library never auto-unmounts between tests.
+afterEach(cleanup);
+
 // jsdom has neither; the composer measures itself and ThemeProvider reads the
 // colour-scheme query, both on mount.
 if (!('ResizeObserver' in globalThis)) {


### PR DESCRIPTION
Adds **Delete conversation** to the conversation actions menu, behind a confirmation dialog that names the conversation and states that it disappears for everyone in it. The row leaves the cached list immediately and returns if the call fails; deleting clears the draft, the selection, and the route.

A link to a deleted conversation now falls back to the empty state instead of rendering a placeholder header over a transcript the app no longer lists.

Also fixes test isolation: without vitest globals, testing-library never unmounted between tests, so a second `render` in a file leaked the first one's DOM.

Needs agynio/api#189 (merged), agynio/chat#36, agynio/gateway#208.
Spec: [changes/2026-08-13-chat-deletion.md](https://github.com/agynio/architecture/blob/main/changes/2026-08-13-chat-deletion.md)